### PR TITLE
Add a check for unmatching mapping and coords file - close #21

### DIFF
--- a/scripts/make_emperor.py
+++ b/scripts/make_emperor.py
@@ -100,7 +100,7 @@ def main():
     sids_intersection = len(set(zip(*mapping_data)[0]) & set(parsed_coords[0]))
 
     # sample ids must be shared between files
-    if sids_intersection > 0:
+    if sids_intersection <= 0:
         option_parser.error('The sample identifiers in the coordinates file '
             'must have at least one match with the data contained in mapping '
             'file. Verify you are using a coordinates file and a mapping file '


### PR DESCRIPTION
The script interface will now display an error when there are no samples
in common between the mapping file and the coords file.

The script interface will now display an error when the samples
represented in the coordinates file are not all represented by the
mapping file. The user however can override this with an extra flag.

This should fix issue #21
