### PR TITLE
Change default output path from ./ to emperor

### DIFF
--- a/scripts/make_emperor.py
+++ b/scripts/make_emperor.py
@@ -113,7 +113,8 @@ script_info['optional_options'] = [
     'file at the time-point zero and the missing pH values at 7, you would have'
     ' to pass  \'-x Time:0 -x pH:7\'.', action='append', default=None),
     make_option('-o','--output_dir',type="new_dirpath", help='path to the '
-    'output directory that will contain the PCoA plot.')
+    'output directory that will contain the PCoA plot. [default: %default]',
+    default='emperor')
 ]
 script_info['version'] = __version__
 
@@ -312,14 +313,10 @@ def main():
     mapping_data, header = preprocess_mapping_file(mapping_data, header,
         color_by_column_names, unique=not add_unique_columns)
 
-    # use the current working directory as default
-    if opts.output_dir:
-        create_dir(opts.output_dir,False)
-        dir_path=opts.output_dir
-    else:
-        dir_path='./'
+    # create the output directory before creating any other output
+    create_dir(opts.output_dir,False)
 
-    fp_out = open(join(dir_path, 'index.html'),'w')
+    fp_out = open(join(output_dir, 'index.html'),'w')
     fp_out.write(EMPEROR_HEADER_HTML_STRING)
 
     # write the html file
@@ -327,7 +324,7 @@ def main():
     fp_out.write(format_pcoa_to_js(coords_headers, coords_data,
         coords_eigenvalues, coords_pct, custom_axes, coords_low, coords_high))
     fp_out.write(EMPEROR_FOOTER_HTML_STRING)
-    copy_support_files(dir_path)
+    copy_support_files(output_dir)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The -o option now has a default, previously it was not the case as it
would manually prepend ./ to every output.

Fixes #60
