### PR TITLE
Fix bug reported in #66

### DIFF
--- a/emperor/util.py
+++ b/emperor/util.py
@@ -59,13 +59,15 @@ def copy_support_files(file_path):
         create_dir(file_path, False)
 
     # shutil.copytree does not provide an easy way to copy the contents of a
-    # directory into another existing directory, hence the system call
-    cmd = 'cp -R %s/* %s' % (get_emperor_support_files_dir(), abspath(file_path))
+    # directory into another existing directory, hence the system call.
+    # use double quotes for the paths to escape any invalid chracter(s)/spaces
+    cmd = 'cp -R "%s/"* "%s"' % (get_emperor_support_files_dir(),
+        abspath(file_path))
     cmd_o, cmd_e, cmd_r = qiime_system_call(cmd)
 
     if cmd_e:
         raise EmperorSupportFilesError, "Error found whilst trying to copy " +\
-            "the support files:\n%s\n Could not execute: %s" % cmd_e, cmd
+            "the support files:\n%s\n Could not execute: %s" % (cmd_e, cmd)
 
     return
 
@@ -306,7 +308,7 @@ def fill_mapping_field_from_mapping_file(data, headers, values,
         try:
             header_index = headers.index(key)
         except ValueError:
-            raise ValueError, ("The header %s does not exist in the mapping file"
+            raise ValueError,("The header %s does not exist in the mapping file"
                 % key)
 
         # fill in the data

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -29,6 +29,8 @@ class TopLevelTests(TestCase):
             'LinkerPrimerSequence', 'Treatment', 'DOB', 'Description']
         self.valid_columns = ['Treatment', 'DOB']
         self.support_files_filename = get_qiime_temp_dir()
+        self.support_files_filename_spaces = join(get_qiime_temp_dir(),
+            'Directory With Spaces/AndNoSpaces')
 
         # data for the custom axes, contains columns that are gradients
         self.mapping_file_data_gradient = MAPPING_FILE_DATA_GRADIENT
@@ -81,6 +83,12 @@ class TopLevelTests(TestCase):
         """Test the support files are correctly copied to a file path"""
         copy_support_files(self.support_files_filename)
         self.assertTrue(exists(join(self.support_files_filename,
+            'emperor_required_resources/')))
+
+        # related to https://github.com/qiime/emperor/issues/66
+        # the target path has spaces, the support files function will work fine
+        copy_support_files(self.support_files_filename_spaces)
+        self.assertTrue(exists(join(self.support_files_filename_spaces,
             'emperor_required_resources/')))
 
     def test_preprocess_mapping_file(self):


### PR DESCRIPTION
The `copy_support_files` function was not accounting for filepaths that
contain spaces or other invalid characters, hence when trying to run
make_emperor.py and setting the output path to something like
`/Users/jappleseed/data/oct 12/` would fail because of the `oct 12`
component in the path.

A new test has been added to `test_util.py`.

Fix #66
