### PR TITLE
Add remove_empty_rows to parse_otu_table

### DIFF
--- a/scripts/make_emperor.py
+++ b/scripts/make_emperor.py
@@ -292,7 +292,7 @@ def main():
         try:
             # for summarized tables the "otu_ids" are really the "lineages"
             otu_sample_ids, lineages, otu_table, _ = parse_otu_table(open(
-                taxa_fp, 'U'), count_map_f=float)
+                taxa_fp, 'U'), count_map_f=float, remove_empty_rows=True)
         except ValueError, e:
             option_parser.error('There was a problem parsing the --taxa_fp: %s'%
                 e.message)


### PR DESCRIPTION
Previously this option was removed as it made the tests in Jenkins fail
because it was relying on QIIME 1.6.0.

Fixes #73
