### PR TITLE
Change URLs to point to emperor.colorado.edu

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ make_emperor.py -i unweighted_unifrac_pc_time.txt -m mapping_with_time.txt -a TI
 
 Some build examples are bundled with every Emperor repository, you can begin exploring some sample data using **Google Chrome**:
 
-- To see an example of a simple PCoA plot, see this [link](http://htmlpreview.github.io/?https://github.com/qiime/emperor/blob/master/tests/scripts_test_data/make_emperor/emperor_output/index.html).
-- To see an example of a Jackknifed plot, see this [link](http://htmlpreview.github.io/?https://github.com/qiime/emperor/blob/master/tests/scripts_test_data/make_emperor/jackknifed_pcoa/index.html).
-- To see an example of a PCoA Biplot, see this [link](http://htmlpreview.github.io/?https://github.com/qiime/emperor/blob/master/tests/scripts_test_data/make_emperor/biplot/index.html).
-- To see an example of a PCoA plot with connecting lines between samples, see this [link](http://htmlpreview.github.io/?https://github.com/qiime/emperor/blob/master/tests/scripts_test_data/make_emperor/vectors/index.html).
-- To see an example of a PCoA plot with connecting lines between samples and an explicit axis, see this [link](http://htmlpreview.github.io/?https://github.com/qiime/emperor/blob/master/tests/scripts_test_data/make_emperor/sorted_by_DOB/index.html).
+- To see an example of a simple PCoA plot, see this [link](http://emperor.colorado.edu/emperor_output/index.html).
+- To see an example of a Jackknifed plot, see this [link](http://emperor.colorado.edu/jackknifed_pcoa/index.html).
+- To see an example of a PCoA Biplot, see this [link](http://emperor.colorado.edu/biplot/index.html).
+- To see an example of a PCoA plot with connecting lines between samples, see this [link](http://emperor.colorado.edu/vectors/index.html).
+- To see an example of a PCoA plot with connecting lines between samples and an explicit axis, see this [link](http://emperor.colorado.edu/sorted_by_DOB/index.html).


### PR DESCRIPTION
The usage examples are now hosted in emperor.colorado.edu, all examples
should be accessible from the README.md file of this branch and once
merged from the README.md of the main repository.

Note that the last of the examples is broken because of a bug with the
parallel plots.

Fixes #96
