### PR TITLE
Fixes #185 by changing the Chrome link from Spanish to English

### DIFF
--- a/doc/tutorial_index.html
+++ b/doc/tutorial_index.html
@@ -118,7 +118,7 @@
             <br>
             The dataset that we will use to exemplify Emperor’s functionality, comes from the <a href="http://www.pnas.org/content/107/14/6477.long">Fierer et. al. 2010</a> article, where three individuals and their keyboards were sampled, Figure 1.
             <br>
-            To get started, first download and unzip these <a href="files/files.zip">files</a>, here you will find a principal coordinates file, and a mapping file. These input files are in the standard format used in <a href="http://www.qiime.org">QIIME</a>. Before continuing with the tutorial make sure you have the latest version of <a href=" https://www.google.com/intl/es/chrome/browser/">Google Chrome</a> installed in your computer.
+            To get started, first download and unzip these <a href="files/files.zip">files</a>, here you will find a principal coordinates file, and a mapping file. These input files are in the standard format used in <a href="http://www.qiime.org">QIIME</a>. Before continuing with the tutorial make sure you have the latest version of <a href=" https://www.google.com/intl/en/chrome/browser/">Google Chrome</a> installed in your computer.
             <br>
           </p>
         <hr>


### PR DESCRIPTION
Changes the Chrome link in the tutorial_index page from the Spanish version to the English version (#185).
