### PR TITLE
Move "Use gradient colors" to Colors tab

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 Emperor 0.9.3 (changes since Emperor 0.9.2 go here)
 ===================================================
 
-
+* `Use gradient colors` checkbox is now found under the `Colors` tab.
 
 Emperor 0.9.2 (24 Oct 2013)
 ===========================

--- a/emperor/format.py
+++ b/emperor/format.py
@@ -607,6 +607,8 @@ document.getElementById("logotable").style.display = 'none';
         </div>
         <div id="colorby">
             <br>%s
+            <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
+            <br><br>
             <select id="colorbycombo" onchange="colorByMenuChanged()" size="3">
             </select>
             <div class="list" id="colorbylist">
@@ -662,7 +664,6 @@ document.getElementById("logotable").style.display = 'none';
                 <br>
                 <br>
                 <form name="settingsoptionscolor">
-                <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
                 </form>%s%s%s
                 <br>
                 <label for="sphereopacity" class="text">Sphere Opacity</label>

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -605,6 +605,8 @@ document.getElementById("logotable").style.display = 'none';
         </div>
         <div id="colorby">
             <br>
+            <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
+            <br><br>
             <select id="colorbycombo" onchange="colorByMenuChanged()" size="3">
             </select>
             <div class="list" id="colorbylist">
@@ -660,7 +662,6 @@ document.getElementById("logotable").style.display = 'none';
                 <br>
                 <br>
                 <form name="settingsoptionscolor">
-                <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
                 </form>
             <br>
             <label for="ellipseopacity" class="text">Ellipse Opacity</label>
@@ -787,6 +788,8 @@ document.getElementById("logotable").style.display = 'none';
                 <tr><td><div id="taxaspherescolor" class="colorbox" name="taxaspherescolor"></div></td><td title="taxacolor">Taxa Spheres Color</td></tr>
             </table>
             <br>
+            <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
+            <br><br>
             <select id="colorbycombo" onchange="colorByMenuChanged()" size="3">
             </select>
             <div class="list" id="colorbylist">
@@ -852,7 +855,6 @@ document.getElementById("logotable").style.display = 'none';
                 <br>
                 <br>
                 <form name="settingsoptionscolor">
-                <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
                 </form>
                 <br>
                 <label for="sphereopacity" class="text">Sphere Opacity</label>
@@ -970,6 +972,8 @@ document.getElementById("logotable").style.display = 'none';
         </div>
         <div id="colorby">
             <br>
+            <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
+            <br><br>
             <select id="colorbycombo" onchange="colorByMenuChanged()" size="3">
             </select>
             <div class="list" id="colorbylist">
@@ -1025,7 +1029,6 @@ document.getElementById("logotable").style.display = 'none';
                 <br>
                 <br>
                 <form name="settingsoptionscolor">
-                <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
                 </form>
                 <br>
                 <label for="sphereopacity" class="text">Sphere Opacity</label>
@@ -1142,6 +1145,8 @@ document.getElementById("logotable").style.display = 'none';
         </div>
         <div id="colorby">
             <br>
+            <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
+            <br><br>
             <select id="colorbycombo" onchange="colorByMenuChanged()" size="3">
             </select>
             <div class="list" id="colorbylist">
@@ -1197,7 +1202,6 @@ document.getElementById("logotable").style.display = 'none';
                 <br>
                 <br>
                 <form name="settingsoptionscolor">
-                <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
                 </form>
             <br>
             <label for="vectorsopacity" class="text">Vectors Opacity</label>
@@ -1318,6 +1322,8 @@ document.getElementById("logotable").style.display = 'none';
         </div>
         <div id="colorby">
             <br>
+            <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
+            <br><br>
             <select id="colorbycombo" onchange="colorByMenuChanged()" size="3">
             </select>
             <div class="list" id="colorbylist">
@@ -1376,7 +1382,6 @@ document.getElementById("logotable").style.display = 'none';
                 <br>
                 <br>
                 <form name="settingsoptionscolor">
-                <input type="checkbox" onchange="toggleContinuousAndDiscreteColors(this)" id="discreteorcontinuouscolors" name="discreteorcontinuouscolors">  Use gradient colors</input>
                 </form>
             <br>
             <form name="edgesvisibility">


### PR DESCRIPTION
The checkbox to switch between coloring schemes (continuous or
discrete), used to be in the 'View' tab but is now found under the
'Colors' tab. The test module code was updated to reflect this changes.

Add a note to the ChangeLog.md file about this change.

Fixes #204
