### PR TITLE
Add message about Google Chrome being 32-bit

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -123,7 +123,7 @@
           Due to it’s tailor-made graphical user interface, delving into a new dataset to elucidate the patterns hidden in the data, has never been easier. Emperor brings a rich set of customizations and modifications that can be integrated into any <a href="http://qiime.org">QIIME</a> compliant dataset; with lightweight data files and hardware accelerated graphics, constitutes itself as the state of the art for analyzing N-dimensional data using principal coordinates analysis.
         </p>
         <br>
-        <strong><p class="text-error lead" align="justify">We've encountered that for large studies (more than five thousand samples) a 64-bit browser might be needed. Even though we recommend Google Chrome, there are no official 64-bit binaries for OS X or Windows (Linux builds are 64-bit by default), if you encounter this problem you should be able to open the visualization with Safari or Firefox.</p></strong>
+        <strong><p class="text-error lead" align="justify">We've encountered that for large studies (more than five thousand samples) a 64-bit browser is needed. Even though we recommend Google Chrome, there are no official 64-bit binaries for OS X or Windows (Linux builds are 64-bit by default, see <a href="https://code.google.com/p/chromium/issues/detail?id=18323">issue #18323</a> and <a href="https://code.google.com/p/chromium/issues/detail?id=312958">issue #312958</a>), if you encounter this problem you should be able to open the visualization with Safari or Firefox.</p></strong>
       </div>
 
       <hr>


### PR DESCRIPTION
I've added a message in red to the documentation's index explaining this
problem (for more details, see below).

After an e-mail exchange with Chromium engineers we've figured that
there are some cases where the amount of samples in a study requires
a 64-bit version of Google Chrome which is only available when running
under Linux as that's the only officially supported platform for 64-bit
builds of Google Chrome. See the following link:
    https://code.google.com/p/chromium/issues/detail?id=312958

There are open tickets in their issue tracker trying to target the
release of a 64-bit version for OS X, however this has not been
addressed yet:
    https://code.google.com/p/chromium/issues/detail?id=18323

It's worth adding that in previous versions of Google Chrome this didn't
matter and visualizations would work without a problem, hence the
suggestion now is to open the bigger studies using Safari or Firefox
(which we've tested and work just fine).
