### PR TITLE
fixing issue_266

### DIFF
--- a/emperor/parse.py
+++ b/emperor/parse.py
@@ -38,4 +38,6 @@ def parse_coords(lines):
         return (pcoa_results.site_ids, pcoa_results.site, pcoa_results.eigvals,
                 pcoa_results.proportion_explained)
     except FileFormatError:
+        if type(lines) == file:
+            lines.seek(0)
         return qiime_parse_coords(lines)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -12,6 +12,8 @@ __email__ = "josenavasmolina@gmail.com"
 __status__ = "Development"
 
 from unittest import TestCase, main
+from tempfile import mkstemp
+from os import close
 
 import numpy as np
 import numpy.testing as npt
@@ -37,9 +39,30 @@ class ParseTests(TestCase):
         npt.assert_almost_equal(obs[3], exp[3])
 
     def test_parse_coords_qiime(self):
-        """parse_coords should handle old qiime PCoA coords file"""
+        """parse_coords should handle old qiime PCoA coords format"""
         coords = qiime_pcoa_file.splitlines()
         obs = parse_coords(coords)
+        exp = (['A', 'B', 'C'],
+               np.array([[.11, .09, .23], [.03, .07, -.26], [.12, .06, -.32]]),
+               np.array([4.94, 1.79, 1.50]),
+               np.array([14.3, 5.2, 4.3]))
+        # test the header and the values apart from each other
+        self.assertEqual(obs[0], exp[0])
+        npt.assert_almost_equal(obs[1], exp[1])
+        npt.assert_almost_equal(obs[2], exp[2])
+        npt.assert_almost_equal(obs[3], exp[3])
+
+    def test_parse_coords_qiime_file(self):
+        """parse_coords should handle old qiime PCoA coords file"""
+        fd, fp = mkstemp()
+        close(fd)
+
+        with open(fp, 'w') as f:
+            f.write(qiime_pcoa_file)
+
+        with open(fp, 'U') as f:
+            obs = parse_coords(f)
+
         exp = (['A', 'B', 'C'],
                np.array([[.11, .09, .23], [.03, .07, -.26], [.12, .06, -.32]]),
                np.array([4.94, 1.79, 1.50]),


### PR DESCRIPTION
@ElDeveloper this fixes #266

The issue is that when we are dealing with files, the skbio's parser already moves the file pointer, so when it fails and got passed to the QIIME parser, it is no longer on position 0 in the file.

I added a new test case for this situation.
