### PR TITLE
ENH: Speed up the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   # Update conda itself
   - conda update --yes conda
 install:
-  - conda create --yes -n env_name python=$TRAVIS_PYTHON_VERSION pip numpy=$NUMPY_VERSION scipy matplotlib
+  - conda create --yes -n env_name python=$TRAVIS_PYTHON_VERSION pip numpy=$NUMPY_VERSION scipy matplotlib openpyxl=1.8.2 pandas
   - source activate env_name
   - pip install -r requirements.txt -e .
 script:


### PR DESCRIPTION
Installing Pandas and openpyxl with conda is much faster than resolving the
requirements using pip.
