### PR TITLE
DOC: Improve error message

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ Emperor ChangeLog
 Emperor 0.9.5-dev (changes since Emperor 0.9.5 go here)
 -------------------------------------------------------
 
+* Improved error message when none of the samples match between coordinates and mapping file.
+
 Emperor 0.9.5 (14 Nov 2014)
 ---------------------------
 

--- a/scripts/make_emperor.py
+++ b/scripts/make_emperor.py
@@ -432,10 +432,10 @@ def main():
 
     # sample ids must be shared between files
     if number_intersected_sids <= 0:
-        option_parser.error('The sample identifiers in the coordinates file '
-            'must have at least one match with the data contained in mapping '
-            'file. Verify you are using a coordinates file and a mapping file '
-            'that belong to the same dataset.')
+        option_parser.error('None of your sample identifiers match between the'
+                            ' mapping file and the coordinates file. Verify '
+                            'you are using a coordinates file and a mapping '
+                            'file that belong to the same dataset.')
 
     # the intersection of the sample ids in the coords and the sample ids in the
     # mapping file must at the very least include all ids in the coords file


### PR DESCRIPTION
It was pointed out that the error message printed when sample names didn't
match between coordinates and mapping file was unclear. So the message has
been rephrased.