### PR TITLE
DOC: Remove note about Chrome 32-bit

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -137,8 +137,6 @@
         </p>
         <img src="img/sample_1.png" alt="Emperor">
         <br>
-        <strong><p class="text-error lead" align="justify">We've encountered that for large studies (more than five thousand samples) a 64-bit browser is needed. Even though we recommend Google Chrome, there are no official 64-bit binaries for OS X or Windows (Linux builds are 64-bit by default, see <a href="https://code.google.com/p/chromium/issues/detail?id=18323">issue #18323</a> and <a href="https://code.google.com/p/chromium/issues/detail?id=312958">issue #312958</a>), if you encounter this problem you should be able to open the visualization with Safari or Firefox.</p></strong>
-
       </div>
 
       <hr>


### PR DESCRIPTION
As of 39.x Chrome is 64-bit for the mac :beers: 
https://code.google.com/p/chromium/issues/detail?id=18323

Fixes #322