### PR TITLE
DOC: Update link pointing to version 0.9.3

### DIFF
--- a/doc/installation_index.html
+++ b/doc/installation_index.html
@@ -121,7 +121,7 @@
         Emperor is a python package hosted in <a href="https://github.com/biocore/emperor/">GitHub</a> that relies on <a href="http://www.numpy.org/">NumPy</a>, <a href="http://scikit-bio.org">scikit-bio</a> and <a href="ftp://thebeast.colorado.edu/pub/qcli-releases/qcli-0.1.0.tar.gz">qcli</a>. These packages must be installed prior running the <code>setup.py</code> script.
         </p>
         <p align="center">
-          <a class="btn btn-large btn-primary" href="https://github.com/biocore/emperor/archive/0.9.3.zip">
+          <a class="btn btn-large btn-primary" href="https://github.com/biocore/emperor/releases">
             Download Stable Version
           </a>
           <a class="btn btn-large btn-warning" href="https://github.com/biocore/emperor/archive/master.zip">


### PR DESCRIPTION
The button in the documentation pointed to version 0.9.3 as the "stable" 
version, I've changed the link to point to the releases page in GitHub, which
should always list the latest release at the top.