### PR TITLE
BUG: Fix bug with animations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ Emperor ChangeLog
 Emperor 0.9.51-dev (changes since Emperor 0.9.5 go here)
 --------------------------------------------------------
 
+### Bug fixes
+
+* Fix bug where Emperor would try to animate trajectories with a single timepoint i.e. a single unique value in the gradient category.
 
 ### Miscellaneous
 

--- a/emperor/support_files/js/animate.js
+++ b/emperor/support_files/js/animate.js
@@ -162,8 +162,10 @@ AnimationDirector.prototype.initializeTrajectories = function(){
                               'z':chewedDataBuffer[index]['z']});
     }
 
-    // don't add a new trajectory
-    if (sampleNamesBuffer.length <= 1){
+    // Don't add a trajectory unless it has more than one different points
+    // in the gradient. There's no reason why we should animate a trajectory
+    // that has a timepoint in 0, 0 and 0 or one that has a timepoint in 0.
+    if (_.uniq(gradientPointsBuffer).length <= 1){
       continue;
     }
 

--- a/emperor/support_files/js/animate.js
+++ b/emperor/support_files/js/animate.js
@@ -166,7 +166,8 @@ AnimationDirector.prototype.initializeTrajectories = function(){
     // gradient. For example, there's no reason why we should animate a
     // trajectory that has 3 samples at timepoint 0 ([0, 0, 0]) or a trajectory
     // that has just one sample at timepoint 0 ([0])
-    if (_.uniq(gradientPointsBuffer).length <= 1){
+    if (sampleNamesBuffer.length <=1 ||
+        _.uniq(gradientPointsBuffer).length <= 1){
       continue;
     }
 

--- a/emperor/support_files/js/animate.js
+++ b/emperor/support_files/js/animate.js
@@ -162,7 +162,7 @@ AnimationDirector.prototype.initializeTrajectories = function(){
                               'z':chewedDataBuffer[index]['z']});
     }
 
-    // Don't add a trajectory unless it has more than one samples in the
+    // Don't add a trajectory unless it has more than one sample in the
     // gradient. For example, there's no reason why we should animate a
     // trajectory that has 3 samples at timepoint 0 ([0, 0, 0]) or a trajectory
     // that has just one sample at timepoint 0 ([0])

--- a/emperor/support_files/js/animate.js
+++ b/emperor/support_files/js/animate.js
@@ -162,9 +162,10 @@ AnimationDirector.prototype.initializeTrajectories = function(){
                               'z':chewedDataBuffer[index]['z']});
     }
 
-    // Don't add a trajectory unless it has more than one different points
-    // in the gradient. There's no reason why we should animate a trajectory
-    // that has a timepoint in 0, 0 and 0 or one that has a timepoint in 0.
+    // Don't add a trajectory unless it has more than one samples in the
+    // gradient. For example, there's no reason why we should animate a
+    // trajectory that has 3 samples at timepoint 0 ([0, 0, 0]) or a trajectory
+    // that has just one sample at timepoint 0 ([0])
     if (_.uniq(gradientPointsBuffer).length <= 1){
       continue;
     }

--- a/tests/javascript_tests/test_animate.js
+++ b/tests/javascript_tests/test_animate.js
@@ -120,6 +120,10 @@ $(document).ready(function() {
               'category name (C) is assigned correctly');
         equal(director.trajectories[1].metadataCategoryName, 'D', 'The '+
               'category name (D) is assigned correctly');
+        deepEqual(director.trajectories[0].gradientPoints,
+                  ["0", "1", "2"], 'Correct time points (C)')
+        deepEqual(director.trajectories[1].gradientPoints,
+                  ["-9999", "0", "100000"], 'Correct time points (D)')
     });
 
     /**

--- a/tests/javascript_tests/test_animate.js
+++ b/tests/javascript_tests/test_animate.js
@@ -39,6 +39,12 @@ $(document).ready(function() {
             coordinatesDataShort['PC.635'] = { 'name': 'PC.635', 'color': 0, 'x': -0.237661, 'y': 0.046053, 'z': -0.138136, 'P1': -0.237661, 'P2': 0.046053, 'P3': -0.138136, 'P4': 0.159061, 'P5': -0.247485, 'P6': -0.115211, 'P7': -0.112864, 'P8': 0.064794 };
             coordinatesDataShort['PC.356'] = { 'name': 'PC.356', 'color': 0, 'x': 0.228820, 'y': -0.130142, 'z': -0.287149, 'P1': 0.228820, 'P2': -0.130142, 'P3': -0.287149, 'P4': 0.086450, 'P5': 0.044295, 'P6': 0.206043, 'P7': 0.031000, 'P8': 0.071992 };
             coordinatesDataShort['PC.481'] = { 'name': 'PC.481', 'color': 0, 'x': 0.042263, 'y': -0.013968, 'z': 0.063531, 'P1': 0.042263, 'P2': -0.013968, 'P3': 0.063531, 'P4': -0.346121, 'P5': -0.127814, 'P6': 0.013935, 'P7': 0.030021, 'P8': 0.140148 };
+
+            // trajectories with only one unique timepoint in different cases
+            // (1) all timepoints with the same value
+            // (2) a single timepoint
+            mappingFileHeadersUnique = ['SampleID','LinkerPrimerSequence','Treatment','DOB'];
+            mappingFileDataUnique = { 'PC.481': ['PC.481','YATGCTGCCTCCCGTAGGAGT','A','0'],'PC.607': ['PC.607','YATGCTGCCTCCCGTAGGAGT','B','0'],'PC.634': ['PC.634','YATGCTGCCTCCCGTAGGAGT','B','0'],'PC.635': ['PC.635','YATGCTGCCTCCCGTAGGAGT','C','0'],'PC.593': ['PC.593','YATGCTGCCTCCCGTAGGAGT','C','1'],'PC.636': ['PC.636','YATGCTGCCTCCCGTAGGAGT','C','2'],'PC.355': ['PC.355','YATGCTGCCTCCCGTAGGAGT','D','-9999'],'PC.354': ['PC.354','YATGCTGCCTCCCGTAGGAGT','D','0'],'PC.356': ['PC.356','YATGCTGCCTCCCGTAGGAGT','D','100000'] };
         },
 
         teardown: function(){
@@ -99,6 +105,21 @@ $(document).ready(function() {
                   {"x": -0.237661, "y": 0.046053, "z": -0.138136},
                   {"x": -0.276542, "y": -0.144964, "z": 0.066647}],
                   'Fast');
+        equal(director.trajectories.length, 2, 'The number of trajectories is '+
+              'correct');
+    });
+
+    test('Test useless trajectories are removed', function(){
+        var director = new AnimationDirector(mappingFileHeadersUnique,
+                                             mappingFileDataUnique,
+                                             coordinatesData, 'DOB',
+                                             'Treatment', 1000, 10);
+        equal(director.trajectories.length, 2, 'The number of trajectories is '+
+              'correct');
+        equal(director.trajectories[0].metadataCategoryName, 'C', 'The '+
+              'category name (C) is assigned correctly');
+        equal(director.trajectories[1].metadataCategoryName, 'D', 'The '+
+              'category name (D) is assigned correctly');
     });
 
     /**


### PR DESCRIPTION
The framework would try to animate trajectories with a single unique 
timepoint, even though it makes no sense and those should be ignored as they
are not very relevant in the context of an animation.

I've added a new test case to check for this.