### PR TITLE
DOC/MAINT: URLs now point to emperor.microbio.me

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ Emperor 0.9.51-dev (changes since Emperor 0.9.5 go here)
 * Add [flake8](http://flake8.readthedocs.org/en/2.3.0/) to enforce the PEP-8 coding guidelines in every Travis build ([#342](https://github.com/biocore/emperor/issues/342)).
 * Add an `all` target to get all the needed dependencies for emperor development (`pip install emperor[all]`).
 * Update FileSaver.js to the latest development version and fixes a bug with large file downloads.
+* Emperor's website can now be found by going to [http://emperor.microbio.me](http://emperor.microbio.me)
 
 ### New features
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ make_emperor.py -i unweighted_unifrac_pc_time.txt -m mapping_with_time.txt -a TI
 
 Some build examples are bundled with every Emperor repository, you can begin exploring some sample data using **Google Chrome**:
 
-- To see an example of a simple PCoA plot, see this [link](http://emperor.colorado.edu/master/make_emperor/emperor_output/index.html).
-- To see an example of a Jackknifed plot, see this [link](http://emperor.colorado.edu/master/make_emperor/jackknifed_pcoa/index.html).
-- To see an example of a PCoA Biplot, see this [link](http://emperor.colorado.edu/master/make_emperor/biplot/index.html).
-- To see an example of a PCoA plot with connecting lines between samples, see this [link](http://emperor.colorado.edu/master/make_emperor/vectors/index.html).
-- To see an example of a PCoA plot with connecting lines between samples and an explicit axis, see this [link](http://emperor.colorado.edu/master/make_emperor/sorted_by_DOB/index.html).
+- To see an example of a simple PCoA plot, see this [link](http://emperor.microbio.me/master/make_emperor/emperor_output/index.html).
+- To see an example of a Jackknifed plot, see this [link](http://emperor.microbio.me/master/make_emperor/jackknifed_pcoa/index.html).
+- To see an example of a PCoA Biplot, see this [link](http://emperor.microbio.me/master/make_emperor/biplot/index.html).
+- To see an example of a PCoA plot with connecting lines between samples, see this [link](http://emperor.microbio.me/master/make_emperor/vectors/index.html).
+- To see an example of a PCoA plot with connecting lines between samples and an explicit axis, see this [link](http://emperor.microbio.me/master/make_emperor/sorted_by_DOB/index.html).

--- a/doc/index.html
+++ b/doc/index.html
@@ -146,17 +146,17 @@
         <div class="span4">
           <h2>Biplots</h2>
           <p>To visualize the taxa  driving the differences in a PCoA plot we can use biplots.</p>
-          <p><a class="btn" href="http://emperor.colorado.edu/master/make_emperor/biplot/index.html">Biplots Example &raquo;</a></p>
+          <p><a class="btn" href="http://emperor.microbio.me/master/make_emperor/biplot/index.html">Biplots Example &raquo;</a></p>
         </div>
         <div class="span4">
           <h2>Jackknifing</h2>
           <p>A jackknifed PCoA plot (with confidence intervals for each sample) helps to assure that our rarefaction selection is not the cause of the clustering patterns we are looking in beta diversity.</p>
-          <p><a class="btn" href="http://emperor.colorado.edu/master/make_emperor/jackknifed_pcoa/index.html">Jackknifing Example &raquo;</a></p>
+          <p><a class="btn" href="http://emperor.microbio.me/master/make_emperor/jackknifed_pcoa/index.html">Jackknifing Example &raquo;</a></p>
        </div>
         <div class="span4">
           <h2>Gradients</h2>
           <p>Integrating gradient information to our coloring scheme, such as pH, time, or geographical location can be done in multiple ways with Emperor. One of them, is to add an explicit axis to the plot, from the mapping file.</p>
-          <p><a class="btn" href="http://emperor.colorado.edu/master/make_emperor/vectors/index.html">Gradient Example &raquo;</a></p>
+          <p><a class="btn" href="http://emperor.microbio.me/master/make_emperor/vectors/index.html">Gradient Example &raquo;</a></p>
         </div>
       </div>
 

--- a/doc/installation_index.html
+++ b/doc/installation_index.html
@@ -118,7 +118,7 @@
       </div>
         <h2>Downloading</h2>
         <p class="lead" align="justify">
-        Emperor is a python package hosted in <a href="https://github.com/biocore/emperor/">GitHub</a> that relies on <a href="http://www.numpy.org/">NumPy</a>, <a href="http://scikit-bio.org">scikit-bio</a> and <a href="ftp://thebeast.colorado.edu/pub/qcli-releases/qcli-0.1.0.tar.gz">qcli</a>. These packages must be installed prior running the <code>setup.py</code> script.
+        Emperor is a python package hosted in <a href="https://github.com/biocore/emperor/">GitHub</a> that relies on <a href="http://www.numpy.org/">NumPy</a>, <a href="http://scikit-bio.org">scikit-bio</a> and <a href="https://pypi.python.org/pypi/qcli">qcli</a>. These packages must be installed prior running the <code>setup.py</code> script.
         </p>
         <p align="center">
           <a class="btn btn-large btn-primary" href="https://github.com/biocore/emperor/releases">

--- a/emperor/core.py
+++ b/emperor/core.py
@@ -30,7 +30,7 @@ from emperor.format import (format_mapping_file_to_js, format_pcoa_to_js,
 from emperor._format_strings import EMPEROR_HEADER_HTML_STRING
 
 # we are going to use this remote location to load external resources
-RESOURCES_URL = 'http://emperor.colorado.edu/master/make_emperor/emperor_outpu\
+RESOURCES_URL = 'http://emperor.microbio.me/master/make_emperor/emperor_outpu\
 t/emperor_required_resources'
 
 


### PR DESCRIPTION
We no longer have ownership of emperor.colorado.edu so all resources
should point to emperor.microbio.me.

Fixes #382

I've also updated the script that powers @emperor-helper:
https://github.com/ElDeveloper/worker/commit/bd5ea9d294b16520356154b1674513abc6e1a0b4