### PR TITLE
Add axis lines to ScenePlotView3D

### DIFF
--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -36,6 +36,45 @@ define(['underscore', 'three'], function(_, THREE){
     return u;
   };
 
+
+  /**
+   *
+   * Create a generic THREE.Line object
+   *
+   * @param {start} Array with the x, y and z coordinates of one of the ends
+   * of the line.
+   * @param {end} Array with the x, y and z coordinates of one of the ends
+   * of the line.
+   * @param {color} Integer in hexadecimal base that specifies the color of the
+   * line.
+   * @param {width} Float with the width of the line being drawn.
+   * @param {transparent} Bool, whether the line will be transparent or not.
+   *
+   * @return THREE.Line object.
+   *
+   **/
+  function makeLine(start, end, color, width, transparent){
+    // based on the example described in:
+    // https://github.com/mrdoob/three.js/wiki/Drawing-lines
+    var material, geometry, line;
+
+    // make the material transparent and with full opacity
+    material = new THREE.LineBasicMaterial({color:color, linewidth:width});
+    material.matrixAutoUpdate = true;
+    material.transparent = transparent;
+    material.opacity = 1.0;
+
+    // add the two vertices to the geometry
+    geometry = new THREE.Geometry();
+    geometry.vertices.push(new THREE.Vector3(start[0], start[1], start[2]));
+    geometry.vertices.push(new THREE.Vector3(end[0], end[1], end[2]));
+
+    // the line will contain the two vertices and the described material
+    line = new THREE.Line(geometry, material);
+
+    return line;
+  }
+
   /**
    *
    * Format an SVG string with labels and colors.
@@ -77,5 +116,5 @@ define(['underscore', 'three'], function(_, THREE){
     return labels_svg;
   }
 
-  return formatSVGLegend;
+  return {'formatSVGLegend': formatSVGLegend, 'makeLine': makeLine};
 });

--- a/emperor/support_files/js/model.js
+++ b/emperor/support_files/js/model.js
@@ -298,7 +298,7 @@ function ($, _) {
    *
    * Helper function used to find the minimum and maximum values every
    * dimension in the plottable objects. This function is used with
-   * uderscore.js' reduce function (_.reduce).
+   * underscore.js' reduce function (_.reduce).
    *
    * @param {accumulator} Object with a "min" and "max" arrays that store the
    * minimum and maximum values over all the plottables.

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -119,7 +119,6 @@ define([
         scope.dimensionRanges.min = decomp.dimensionRanges.min.slice();
       }
       else {
-        console.log('so broken');
         // when we have more than one decomposition view we need to figure out
         // the absolute largest range that views span over
         _.each(decomp.dimensionRanges.max, function(value, index){

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -1,7 +1,9 @@
 define([
     "three",
-    "orbitcontrols"
-], function (THREE, OrbitControls) {
+    "orbitcontrols",
+    "draw"
+], function (THREE, OrbitControls, draw) {
+  var makeLine = draw.makeLine;
   /**
    *
    * @name ScenePlotView3D
@@ -14,6 +16,11 @@ define([
    * @property {Float} [yView] vertical position of the scene.
    * @property {Float} [width] width of the scene.
    * @property {Float} [height] height of the scene.
+   * @property {Array} [visibleDimensions] array of integers indicating the index
+   * of the visible dimension at each axis ([x, y, z]).
+   * @property {Object} [dimensionRanges] object with a "min" and "max"
+   * attributes each of which is an array with the ranges that covers all of
+   * the decomposition views.
    *
    * @property {THREE.PerspectiveCamera} [camera] camera used to display the
    * scene.
@@ -51,6 +58,9 @@ define([
     this.width = width;
     this.height = height;
 
+    // used to name the axis lines in the scene
+    this._axisPrefix = 'emperor-axis-line-';
+
     // Set up the camera
     this.camera = new THREE.PerspectiveCamera(35, width/height,
         0.0000001, 10000);
@@ -72,7 +82,7 @@ define([
     }
 
     this.control = new THREE.OrbitControls(this.camera,
-        document.getElementById(div_id));
+                                           document.getElementById(div_id));
     this.control.rotateSpeed = 1.0;
     this.control.zoomSpeed = 1.2;
     this.control.panSpeed = 0.8;
@@ -80,7 +90,101 @@ define([
     this.control.enablePan = true;
     this.control.enableDamping = true;
     this.control.dampingFactor = 0.3;
+
+    this.visibleDimensions = [0, 1, 2];
+    this.dimensionRanges = {'max': [], 'min': []};
+    this.drawAxesWithColor(0xFFFFFF);
   };
+
+  /**
+   *
+   * Utility method to find the union of the ranges in the decomposition views
+   * this method will populate the dimensionRanges attributes.
+   *
+   **/
+  ScenePlotView3D.prototype._unionRanges = function(){
+    var scope = this;
+
+    // means we already have the data, so let's say goodbye
+    if (this.dimensionRanges.max.length !== 0){
+      return;
+    }
+
+    _.each(this.decViews, function(decView, name){
+      // get each decomposition object
+      var decomp = decView.decomp;
+
+      if ( scope.dimensionRanges.max.length === 0 ){
+        scope.dimensionRanges.max = decomp.dimensionRanges.max.slice();
+        scope.dimensionRanges.min = decomp.dimensionRanges.min.slice();
+      }
+      else {
+        console.log('so broken');
+        // when we have more than one decomposition view we need to figure out
+        // the absolute largest range that views span over
+        _.each(decomp.dimensionRanges.max, function(value, index){
+          var vMax = decomp.dimensionRanges.max[index],
+              vMin = decomp.dimensionRanges.min[index];
+
+          if (vMax > scope.dimensionRanges.max[index]){
+            scope.dimensionRanges.max[index] = vMax;
+          }
+          if (vMin < scope.dimensionRanges.min[index]){
+            scope.dimensionRanges.min[index] = vMin;
+          }
+        });
+      }
+    });
+  };
+
+
+  /**
+   *
+   * Draw the axes lines in the plot
+   *
+   * @parameter {color} an integer in hexadecimal that specifies the color of
+   * each of the axes lines, the length of these lines is determined by the
+   * dimensionRanges property.
+   *
+   **/
+  ScenePlotView3D.prototype.drawAxesWithColor = function(color){
+    this._unionRanges();
+
+    // shortcut to the index of the visible dimension and the range object
+    var x = this.visibleDimensions[0], y = this.visibleDimensions[1],
+        z = this.visibleDimensions[2], range = this.dimensionRanges;
+
+    // this is the "origin" of our ordination
+    var start = [range.min[x], range.min[y], range.min[z]];
+
+    var ends = [
+      [range.max[x], range.min[y], range.min[z]],
+      [range.min[x], range.max[y], range.min[z]],
+      [range.min[x], range.min[y], range.max[z]]
+    ];
+
+    this.removeAxes();
+
+    for (var i = 0; i < 3; i++){
+      axisLine = makeLine(start, ends[i], color, 3, false);
+      axisLine.name = this._axisPrefix + i;
+
+      this.scene.add(axisLine);
+    }
+  };
+
+  /**
+   *
+   * Remove the axis lines from the scene
+   *
+   **/
+  ScenePlotView3D.prototype.removeAxes = function(){
+    for (var i = 0; i < 3; i++){
+      var axisLine = this.scene.getObjectByName(this._axisPrefix + i);
+      this.scene.remove(axisLine);
+    }
+  };
+
 
   /**
    *

--- a/examples/build.py
+++ b/examples/build.py
@@ -31,8 +31,8 @@ with open('new-emperor.html', 'w') as f, open('template.html') as temp:
     categories = np.asarray(np.random.randint(1, 1000, N), str)
 
     coords_ids = listify(np.arange(N))
-    coords = listify(np.random.randn(N, 10))
-    pct_var = listify(1/np.exp(np.arange(10)))
+    coords = np.random.randn(N, 10).tolist()
+    pct_var = (1/np.exp(np.arange(10))).tolist()
 
     md_headers = ['SampleID', 'DOB']
     metadata = []

--- a/tests/javascript_tests/test_decomposition_model.js
+++ b/tests/javascript_tests/test_decomposition_model.js
@@ -140,6 +140,13 @@ requirejs([
             8)];
       deepEqual(dm.plottable, exp, "Plottables set correctly");
 
+      deepEqual(dm.dimensionRanges.min, [-0.349339, -0.194113, -0.287149,
+                                         -0.346121, -0.247485, -0.279924,
+                                         -0.229889, -0.255786]);
+      deepEqual(dm.dimensionRanges.max, [0.280399, 0.424147, 0.322871,
+                                         0.183347, 0.17607, 0.206043, 0.244448,
+                                         0.140148]);
+
       equal(dm.length, 9, "Length set correctly");
     });
 
@@ -506,6 +513,25 @@ requirejs([
               "the Decomposition Model object"
               );
         });
+
+    /**
+     *
+     * Test the function used to find minimum and maximum values works.
+     *
+     */
+    test("Test the _minMaxReduce function", function(){
+        var p = new Plottable('PC.635', ['PC.635', 'YATGCTGCCTCCCGTAGGAGT',
+                              'Fast', '20071112'], [-0.237661, 0.046053,
+                              -0.138136, 0.159061, -0.247485, -0.115211,
+                              -0.112864, 0.064794], 1);
+        var accumulator = {'min': [-5, -5, -5, -5, -5, -6, -0.01, -8],
+                           'max': [0, 0, 0, 0, 0, 0, 0, 0]};
+
+        var val = DecompositionModel._minMaxReduce(accumulator, p);
+
+        deepEqual(val.min, [-5, -5, -5, -5, -5, -6, -0.112864, -8]);
+        deepEqual(val.max, [0, 0.046053, 0, 0.159061, 0, 0, 0, 0.064794]);
+    });
 
     /**
      *

--- a/tests/javascript_tests/test_draw.js
+++ b/tests/javascript_tests/test_draw.js
@@ -1,4 +1,6 @@
-requirejs(['draw'], function(formatSVGLegend){
+requirejs(['draw'], function(draw){
+  var formatSVGLegend = draw.formatSVGLegend;
+  var makeLine = draw.makeLine;
   $(document).ready(function() {
 
     module("Drawing utilities", {
@@ -9,6 +11,47 @@ requirejs(['draw'], function(formatSVGLegend){
       teardown: function(){
       }
 
+    });
+
+    /**
+     *
+     * Test that makeLine works
+     *
+     */
+    test("Test makeLine works correctly", function(assert){
+      var testLine = makeLine([0, 0, 0], [1, 1, 1], 0x00ff00, 1, true);
+
+      equal(testLine.material.opacity, 1.0);
+      equal(testLine.material.transparent, true);
+
+      equal(testLine.geometry.vertices[0].x, 0);
+      equal(testLine.geometry.vertices[0].y, 0);
+      equal(testLine.geometry.vertices[0].z, 0);
+
+      equal(testLine.geometry.vertices[1].x, 1);
+      equal(testLine.geometry.vertices[1].y, 1);
+      equal(testLine.geometry.vertices[1].z, 1);
+
+      equal(testLine.material.color.r, 0);
+      equal(testLine.material.color.g, 1);
+      equal(testLine.material.color.b, 0);
+
+      testLine = makeLine([0, 0, 0], [1, 1, 1], 0x00ff00, 1, false);
+
+      equal(testLine.material.opacity, 1.0);
+      equal(testLine.material.transparent, false);
+
+      equal(testLine.geometry.vertices[0].x, 0);
+      equal(testLine.geometry.vertices[0].y, 0);
+      equal(testLine.geometry.vertices[0].z, 0);
+
+      equal(testLine.geometry.vertices[1].x, 1);
+      equal(testLine.geometry.vertices[1].y, 1);
+      equal(testLine.geometry.vertices[1].z, 1);
+
+      equal(testLine.material.color.r, 0);
+      equal(testLine.material.color.g, 1);
+      equal(testLine.material.color.b, 0);
     });
 
     /**

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -89,8 +89,53 @@ requirejs([
 
       equal(spv.width, 20);
       equal(spv.height, 20);
+
+      deepEqual(spv.visibleDimensions, [0, 1, 2]);
+      deepEqual(spv.dimensionRanges.max, [-0.237661, 0.046053, 0.066647,
+                                          0.159061, 0.17607, 0.072969,
+                                          -0.112864, 0.064794]);
+      deepEqual(spv.dimensionRanges.min, [-1, -0.144964, -0.138136, -0.067711,
+                                          -0.247485, -0.115211, -0.229889,
+                                          -0.046599]);
     });
 
+    test('Test the draw axes', function(assert){
+      // We will use SVGRenderer here and in the other tests as we cannot use
+      // WebGLRenderer and test with phantom.js
+      var renderer = new THREE.SVGRenderer({antialias: true});
+      var spv = new ScenePlotView3D(renderer, this.sharedDecompositionViewDict,
+          'fooligans', 0, 0, 20, 20);
+
+      // color the axis lines
+      spv.drawAxesWithColor(0x00FF0F);
+
+      var line;
+
+      for (var i = 0; i < 3; i++){
+        line = spv.scene.getObjectByName('emperor-axis-line-' + i);
+        equal(line.material.color.r, 0);
+        equal(line.material.color.g, 1);
+        equal(line.material.color.b, 0.058823529411764705);
+      }
+    });
+
+    test('Test removing axes', function(assert){
+      // We will use SVGRenderer here and in the other tests as we cannot use
+      // WebGLRenderer and test with phantom.js
+      var renderer = new THREE.SVGRenderer({antialias: true});
+      var spv = new ScenePlotView3D(renderer, this.sharedDecompositionViewDict,
+          'fooligans', 0, 0, 20, 20);
+
+      // remove the axis lines
+      spv.removeAxes();
+
+      var line;
+
+      for (var i = 0; i < 3; i++){
+        line = spv.scene.getObjectByName('emperor-axis-line-' + i);
+        assert.equal(line, undefined);
+      }
+    });
 
     /**
      *


### PR DESCRIPTION
This PR adds the axis lines to the `ScenePlotView3D` object, along with the necessary tests and updates to the decomposition model object.

The strategy here is to get the ranges over each dimension in every decomposition model object, then get all the decomposition model objects in a scene plot view, and union their ranges to get the final range.

-------

I had initially planned to submit a PR for the AxesViewController class, but I think this PR is already big as it is and we might get lost in the details. Also I'm not adding the percentage explained to the plot yet. :fork_and_knife: 