### PR TITLE
Add percentage explained labels

### DIFF
--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -77,6 +77,45 @@ define(['underscore', 'three'], function(_, THREE){
 
   /**
    *
+   * Create a THREE object that displays 2D text, this implementation is based
+   * on the answer found here: http://stackoverflow.com/a/14106703/379593
+   *
+   * @param {position} Array representing the location of the label.
+   * @param {text} String with the text to be shown on screen.
+   * @param {color} Integer in hexadecimal base that represents the color of
+   * the text.
+   *
+   * @return THREE.Sprite object with the text displaying in it.
+   *
+   **/
+  function makeLabel(position, text, color){
+    var canvas = document.createElement('canvas');
+    var size = 512;
+    canvas.width = size;
+    canvas.height = size;
+    var context = canvas.getContext('2d');
+    context.fillStyle = '#ffffff';
+    context.textAlign = 'center';
+    context.font = '30px Arial';
+    context.fillText(text, size/2, size/2);
+
+    var amap = new THREE.Texture(canvas);
+    amap.needsUpdate = true;
+
+    var mat = new THREE.SpriteMaterial({
+        map: amap,
+        transparent: true,
+        color: color
+    });
+
+    var sp = new THREE.Sprite(mat);
+    sp.position.set(position[0], position[1], position[2]);
+
+    return sp;
+  }
+
+  /**
+   *
    * Format an SVG string with labels and colors.
    *
    * @param {labels} Array object with the name of the labels.
@@ -116,5 +155,6 @@ define(['underscore', 'three'], function(_, THREE){
     return labels_svg;
   }
 
-  return {'formatSVGLegend': formatSVGLegend, 'makeLine': makeLine};
+  return {'formatSVGLegend': formatSVGLegend, 'makeLine': makeLine,
+          'makeLabel': makeLabel};
 });

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -168,9 +168,9 @@ define([
       [range.min[x], range.min[y], range.max[z]]
     ];
 
-    for (var i = 0; i < 3; i++){
-      action(start, ends[i], i);
-    }
+    action(start, ends[0], 0);
+    action(start, ends[1], 1);
+    action(start, ends[2], 2);
   };
 
   /**

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -4,6 +4,7 @@ define([
     "draw"
 ], function (THREE, OrbitControls, draw) {
   var makeLine = draw.makeLine;
+  var makeLabel = draw.makeLabel;
   /**
    *
    * @name ScenePlotView3D
@@ -58,8 +59,9 @@ define([
     this.width = width;
     this.height = height;
 
-    // used to name the axis lines in the scene
+    // used to name the axis lines/labels in the scene
     this._axisPrefix = 'emperor-axis-line-';
+    this._axisLabelPrefix = 'emperor-axis-label-';
 
     // Set up the camera
     this.camera = new THREE.PerspectiveCamera(35, width/height,
@@ -94,6 +96,7 @@ define([
     this.visibleDimensions = [0, 1, 2];
     this.dimensionRanges = {'max': [], 'min': []};
     this.drawAxesWithColor(0xFFFFFF);
+    this.drawAxesLabelsWithColor(0xFFFFFF);
   };
 
   /**
@@ -136,17 +139,20 @@ define([
     });
   };
 
-
   /**
    *
-   * Draw the axes lines in the plot
+   * Helper method used to iterate over the ranges of the visible dimensions.
    *
-   * @parameter {color} an integer in hexadecimal that specifies the color of
-   * each of the axes lines, the length of these lines is determined by the
-   * dimensionRanges property.
+   * This function that centralizes the pattern followed by drawAxesWithColor
+   * and drawAxesLabelsWithColor.
+   *
+   * @param {action} a function that can take up to three arguments "start",
+   * "end" and "index".  And for each visible dimension the function will get
+   * the "start" and "end" of the range, and the current "index" of the visible
+   * dimension.
    *
    **/
-  ScenePlotView3D.prototype.drawAxesWithColor = function(color){
+  ScenePlotView3D.prototype._dimensionsIterator = function(action){
     this._unionRanges();
 
     // shortcut to the index of the visible dimension and the range object
@@ -162,13 +168,86 @@ define([
       [range.min[x], range.min[y], range.max[z]]
     ];
 
+    for (var i = 0; i < 3; i++){
+      action(start, ends[i], i);
+    }
+  };
+
+  /**
+   *
+   * Draw the axes lines in the plot
+   *
+   * @parameter {color} an integer in hexadecimal that specifies the color of
+   * each of the axes lines, the length of these lines is determined by the
+   * dimensionRanges property.
+   *
+   **/
+  ScenePlotView3D.prototype.drawAxesWithColor = function(color){
+    var scope = this, axisLine;
+
     this.removeAxes();
 
-    for (var i = 0; i < 3; i++){
-      axisLine = makeLine(start, ends[i], color, 3, false);
-      axisLine.name = this._axisPrefix + i;
+    this._dimensionsIterator(function(start, end, index){
+      axisLine = makeLine(start, end, color, 3, false);
+      axisLine.name = scope._axisPrefix + index;
 
-      this.scene.add(axisLine);
+      scope.scene.add(axisLine);
+    });
+  };
+
+  /**
+   *
+   * Draw the axes labels for each visible dimension.
+   *
+   * @parameter {color} an integer in hexadecimal that specifies the color of
+   * the labels, these labels will be positioned at the end of the axes line.
+   * The text in the labels is determined using the percentage explained by
+   * each dimension and the abbreviated name of a single decomposition object.
+   * Note that we arbitrarily use the first one, as all decomposition objects
+   * presented in the same scene should have the same percentages explained by
+   * each axis.
+   *
+   **/
+  ScenePlotView3D.prototype.drawAxesLabelsWithColor = function(color){
+    var scope = this, axisLabel, decomp, firstKey, text;
+
+    this.removeAxesLabels();
+
+    // get the first decomposition object, it doesn't really mater which one
+    // we look at though, as all of them should have the same percentage
+    // explained on each axis
+    firstKey = _.keys(this.decViews)[0];
+    decomp = this.decViews[firstKey].decomp;
+
+    this._dimensionsIterator(function(start, end, index){
+
+      // construct a label of the format: AbbNam (xx.xx %)
+      text = decomp.abbreviatedName + ' (' +
+             decomp.percExpl[index].toPrecision(4) + ' %)';
+
+      axisLabel = makeLabel(end, text, color);
+      axisLabel.name = scope._axisLabelPrefix + index;
+
+      scope.scene.add(axisLabel);
+    });
+  };
+
+  /**
+   *
+   * Helper method to remove objects that match a prefix from the view's scene
+   * this method is used by removeAxes and removeAxesLabels. This function
+   * iterates "num" times, and for each iteration it finds and removes objects
+   * with the name of the form "prefix" + "iteration".
+   *
+   * @param {prefix} a string indicating the label that will prepended to the
+   * iterating index.
+   * @param {num} an integer specifying the number of iterations to perform.
+   *
+   **/
+  ScenePlotView3D.prototype._removeObjectsWithPrefix = function(prefix, num){
+    for (var i = 0; i < num; i++){
+      var axisLine = this.scene.getObjectByName(prefix + i);
+      this.scene.remove(axisLine);
     }
   };
 
@@ -178,12 +257,17 @@ define([
    *
    **/
   ScenePlotView3D.prototype.removeAxes = function(){
-    for (var i = 0; i < 3; i++){
-      var axisLine = this.scene.getObjectByName(this._axisPrefix + i);
-      this.scene.remove(axisLine);
-    }
+    this._removeObjectsWithPrefix(this._axisPrefix, 3);
   };
 
+  /**
+   *
+   * Remove the axis labels from the scene
+   *
+   **/
+  ScenePlotView3D.prototype.removeAxesLabels = function(){
+    this._removeObjectsWithPrefix(this._axisLabelPrefix, 3);
+  };
 
   /**
    *

--- a/examples/template.html
+++ b/examples/template.html
@@ -59,6 +59,7 @@
           'model': './js/model',
           'view': './js/view',
           'controller': './js/controller',
+          'draw': './js/draw',
           'scene3d': './js/sceneplotview3d',
           'viewcontroller': './js/view-controller',
           'colorviewcontroller': './js/color-view-controller',

--- a/tests/javascript_tests/test_draw.js
+++ b/tests/javascript_tests/test_draw.js
@@ -1,6 +1,7 @@
 requirejs(['draw'], function(draw){
   var formatSVGLegend = draw.formatSVGLegend;
   var makeLine = draw.makeLine;
+  var makeLabel = draw.makeLabel;
   $(document).ready(function() {
 
     module("Drawing utilities", {
@@ -53,6 +54,24 @@ requirejs(['draw'], function(draw){
       equal(testLine.material.color.g, 1);
       equal(testLine.material.color.b, 0);
     });
+
+    /**
+     *
+     * Test that makeLabel works correctly.
+     *
+     */
+    test("Test makeLabel works correctly", function(assert){
+      var label = makeLabel([0, 0, 0], "foolibusters", 0x00FF00);
+
+      equal(label.material.color.r, 0);
+      equal(label.material.color.g, 1);
+      equal(label.material.color.b, 0);
+
+      equal(label.position.x, 0);
+      equal(label.position.y, 0);
+      equal(label.position.z, 0);
+    });
+
 
     /**
      *

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -137,6 +137,53 @@ requirejs([
       }
     });
 
+
+    test('Test the draw axes labels', function(assert){
+      // We will use SVGRenderer here and in the other tests as we cannot use
+      // WebGLRenderer and test with phantom.js
+      var renderer = new THREE.SVGRenderer({antialias: true});
+      var spv = new ScenePlotView3D(renderer, this.sharedDecompositionViewDict,
+          'fooligans', 0, 0, 20, 20);
+
+      // color the axis lines
+      spv.drawAxesLabelsWithColor(0x00FF0F);
+
+      var label, positions = [[-0.237661, -0.144964, -0.138136],
+                              [-1, 0.046053, -0.138136],
+                              [-1, -0.144964, 0.066647]];
+
+      for (var i = 0; i < 3; i++){
+        label = spv.scene.getObjectByName('emperor-axis-label-' + i);
+
+        equal(label.position.x, positions[i][0]);
+        equal(label.position.y, positions[i][1]);
+        equal(label.position.z, positions[i][2]);
+
+        equal(label.material.color.r, 0);
+        equal(label.material.color.g, 1);
+        equal(label.material.color.b, 0.058823529411764705);
+      }
+    });
+
+    test('Test removing axes labels', function(assert){
+      // We will use SVGRenderer here and in the other tests as we cannot use
+      // WebGLRenderer and test with phantom.js
+      var renderer = new THREE.SVGRenderer({antialias: true});
+      var spv = new ScenePlotView3D(renderer, this.sharedDecompositionViewDict,
+          'fooligans', 0, 0, 20, 20);
+
+      // remove the axis lines
+      spv.removeAxesLabels();
+
+      var label;
+
+      for (var i = 0; i < 3; i++){
+        label = spv.scene.getObjectByName('emperor-axis-label-' + i);
+        assert.equal(label, undefined);
+      }
+    });
+
+
     /**
      *
      * Test the setCameraAspectRatio method for ScenePlotView3D


### PR DESCRIPTION
This PR adds the necessary methods to add and remove the axes labels.

I noticed we could abstract out a few patterns so I made a couple helper methods for the add and remove methods. I also noticed we had a problem in the template.html file with a missing dependency declaration.