### PR TITLE
BUG: Remove incorrect callback declaration

### DIFF
--- a/examples/template.html
+++ b/examples/template.html
@@ -24,14 +24,6 @@
     </style>
 
     <script type="text/javascript" src="../emperor/support_files/vendor/js/require-2.1.22.min.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function(){
-        // Fire the window resize here to get the main-template resize to fire
-        // as well
-        $(window).resize(function() {});
-    });
-    </script>
-
   </head>
   <body>
     {% include "../emperor/support_files/templates/main-template.html" %}


### PR DESCRIPTION
This callback was never being executed because `$` is not defined and it
was in fact showing an error in the JavaScript console. Removing this
tag altogether does not seem to affect the behavior of the plot at all.