### PR TITLE
MAINT/ENH: Use scikit-bio>=0.4.0 and scipy>=0.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ python:
   - "2.7"
 env:
   - NUMPY_VERSION=""  WITH_COVERAGE=1 # environment to test with the latest version of NumPy
-  # test only with the latest stable releases of numpy i.e. 1.8.x and 1.7.x
-  - NUMPY_VERSION="<1.9"
-  - NUMPY_VERSION="<1.8"
+  # test only with the latest stable releases of numpy i.e. 1.9.x and 1.10.x
+  - NUMPY_VERSION="<1.10"
+  - NUMPY_VERSION="<1.11"
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
@@ -14,10 +14,10 @@ before_install:
   # Update conda itself
   - conda update --yes conda
 install:
-  - conda create --yes -n env_name python=$TRAVIS_PYTHON_VERSION pip numpy${NUMPY_VERSION} scipy matplotlib openpyxl=1.8.2 pandas nose flake8 pep8 ipython-notebook
+  - conda create --yes -n env_name python=$TRAVIS_PYTHON_VERSION pip numpy${NUMPY_VERSION} 'scipy>=0.17.0' matplotlib openpyxl=1.8.2 pandas nose flake8 pep8 ipython-notebook
   - source activate env_name
   - pip install sphinx sphinx-bootstrap-theme coverage coveralls
-  - pip install -e '.[all]'
+  - pip install -e '.[all]' --no-use-wheel
 script:
   - flake8 emperor/*.py tests/*.py scripts/*.py setup.py
   # execute the full test suite

--- a/emperor/parse.py
+++ b/emperor/parse.py
@@ -7,8 +7,8 @@
 # ----------------------------------------------------------------------------
 from __future__ import division
 
-from skbio.stats.ordination import OrdinationResults
-from skbio.io import FileFormatError
+from skbio import OrdinationResults
+from skbio.io import FileFormatError, IOSourceError
 
 from emperor.qiime_backports.parse import parse_coords as qiime_parse_coords
 
@@ -31,9 +31,10 @@ def parse_coords(lines):
     """
     try:
         pcoa_results = OrdinationResults.read(lines)
-        return (pcoa_results.site_ids, pcoa_results.site, pcoa_results.eigvals,
-                pcoa_results.proportion_explained)
-    except FileFormatError:
+        return (pcoa_results.samples.index.tolist(),
+                pcoa_results.samples.values, pcoa_results.eigvals.values,
+                pcoa_results.proportion_explained.values)
+    except (FileFormatError, IOSourceError):
         try:
             lines.seek(0)
         except AttributeError:

--- a/emperor/qiime_backports/util.py
+++ b/emperor/qiime_backports/util.py
@@ -9,7 +9,8 @@ __maintainer__ = "Yoshiki Vazquez Baeza"
 __email__ = "yoshik89@gmail.com"
 __status__ = "Development"
 
-from skbio.stats.spatial import procrustes
+from scipy.spatial import procrustes
+
 from emperor.qiime_backports.parse import parse_mapping_file_to_dict
 
 from numpy.ma.extras import apply_along_axis

--- a/emperor/support_files/templates/main-template.html
+++ b/emperor/support_files/templates/main-template.html
@@ -74,7 +74,7 @@ function($, model, EmperorController) {
 
   var ids = {{ coords_ids }};
   var coords = {{ coords }};
-  var pct_var = {{ pct_var }};
+  var pct_var = {{ pct_var | map('float') | list }};
   var md_headers = {{ md_headers}};
   var metadata = {{  metadata }};
 

--- a/scripts/make_emperor.py
+++ b/scripts/make_emperor.py
@@ -8,11 +8,13 @@
 # ----------------------------------------------------------------------------
 from __future__ import division
 
+import io
+
 from os import makedirs
 from os.path import join, isdir
+from itertools import chain
 
 from qcli.option_parsing import parse_command_line_parameters, make_option
-from skbio.util import flatten
 
 from emperor.qiime_backports.filter import filter_mapping_file
 from emperor.qiime_backports.parse import (parse_mapping_file,
@@ -453,7 +455,7 @@ def main():
 
         for fp in coord_fps:
             try:
-                parsed = parse_coords(open(fp, 'U'))
+                parsed = parse_coords(io.open(fp, 'r', encoding='utf8'))
             except (ValueError, QiimeParseError):
                 offending_coords_fp.append(fp)
 
@@ -477,9 +479,9 @@ def main():
         # check all files contain the same sample identifiers by flattening the
         # list of available sample ids and returning the sample ids that are
         # in one of the sets of sample ids but not in the globablly shared ids
-        _coords_headers = set(flatten(coords_headers))
+        _coords_headers = set(chain(*coords_headers))
         _per_file_missing = [_coords_headers - set(e) for e in coords_headers]
-        non_shared_ids = set(flatten(_per_file_missing))
+        non_shared_ids = set(chain(*_per_file_missing))
         if non_shared_ids:
             errout = ', '.join(non_shared_ids)
             option_parser.error(("The following sample identifier(s): '%s' "
@@ -503,7 +505,7 @@ def main():
 
     else:
         try:
-            parsed = parse_coords(open(input_coords, 'U'))
+            parsed = parse_coords(io.open(input_coords, 'r', encoding='utf8'))
         # this exception was noticed when there were letters in the coords file
         # other exeptions should be catched here; code will be updated then
         except (ValueError, QiimeParseError):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ Vazquez-Baeza Y, Pirrung M, Gonzalez A, Knight R.
 Gigascience. 2013 Nov 26;2(1):16.
 """
 
-base = {"numpy >= 1.7", "qcli", "scikit-bio >= 0.2.1, < 0.3.0", "jinja2"}
+base = {"numpy >= 1.7", "scipy >= 0.17.0", "qcli",
+        "scikit-bio >= 0.4.0", "jinja2"}
 doc = {"Sphinx >= 1.2.2", "sphinx-bootstrap-theme"}
 test = {"nose >= 0.10.1", "pep8", "flake8"}
 all_deps = base | doc | test

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -12,7 +12,7 @@ codebase and not included in for example format.py, because the length would
 violate PEP-8 rules.
 """
 
-PCOA_STRING = """Eigvals	9
+PCOA_STRING = u"""Eigvals	9
 0.479412119045	0.29201495623	0.247449246064	0.201496072404	0.180076127632\
 	0.147806772727	0.135795927213	0.112259695609	0.0
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,7 @@ from __future__ import division
 
 from unittest import TestCase, main
 from StringIO import StringIO
-from skbio.stats.ordination import OrdinationResults
+from skbio import OrdinationResults
 
 import pandas as pd
 import numpy as np
@@ -20,7 +20,7 @@ from _test_core_strings import PCOA_STRING, HTML_STRING
 
 class TopLevelTests(TestCase):
     def setUp(self):
-        or_f = StringIO(PCOA_STRING)
+        or_f = StringIO(unicode(PCOA_STRING))
         self.ord_res = OrdinationResults.read(or_f)
 
         data = \

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -57,7 +57,7 @@ class ParseTests(TestCase):
         with open(fp, 'w') as f:
             f.write(qiime_pcoa_file)
 
-        with open(fp, 'U') as f:
+        with open(fp, 'r') as f:
             obs = parse_coords(f)
 
         exp = (['A', 'B', 'C'],
@@ -70,7 +70,7 @@ class ParseTests(TestCase):
         npt.assert_almost_equal(obs[2], exp[2])
         npt.assert_almost_equal(obs[3], exp[3])
 
-ordination_results_file = """Eigvals\t3
+ordination_results_file = u"""Eigvals\t3
 4.94\t1.79\t1.50
 
 Proportion explained\t3
@@ -87,7 +87,7 @@ Biplot\t0\t0
 
 Site constraints\t0\t0"""
 
-qiime_pcoa_file = """pc vector number\t1\t2\t3
+qiime_pcoa_file = u"""pc vector number\t1\t2\t3
 A\t0.11\t0.09\t0.23
 B\t0.03\t0.07\t-0.26
 C\t0.12\t0.06\t-0.32

--- a/tests/test_qiime_backports/test_util.py
+++ b/tests/test_qiime_backports/test_util.py
@@ -19,7 +19,7 @@ from unittest import TestCase, main
 from numpy.testing import assert_almost_equal
 from numpy import array, isnan, asarray, arange
 
-from skbio.stats.spatial import procrustes
+from scipy.spatial import procrustes
 
 from emperor.qiime_backports.parse import (parse_mapping_file_to_dict,
     QiimeParseError)


### PR DESCRIPTION
Change the usage of OrdinationResults to match its new API.

Use scipy's procrustes function instead of scikit-bio's. This is the first of many steps towards PY3 compatibility.