### PR TITLE
[DO NOT MERGE] - Run linter and doc creation in travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ doc/source/generated/
 # unwanted files
 examples/new-emperor.html
 .ipynb_checkpoints
+doc/jsdoc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,12 @@ before_install:
 install:
   - conda create --yes -n env_name python=$TRAVIS_PYTHON_VERSION pip numpy${NUMPY_VERSION} 'scipy>=0.17.0' matplotlib openpyxl=1.8.2 pandas nose flake8 pep8 ipython-notebook
   - source activate env_name
+  - pip install https://github.com/google/closure-linter/archive/master.zip
   - pip install sphinx sphinx-bootstrap-theme coverage coveralls
   - pip install -e '.[all]' --no-use-wheel
 script:
   - flake8 emperor/*.py tests/*.py scripts/*.py setup.py
+  - gjslint emperor/support_files/js/*.js tests/javascript_tests/*.js
   # execute the full test suite
   - python tests/all_tests.py
   # we just check coverage in the latest version of NumPy

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - pip install https://github.com/google/closure-linter/archive/master.zip
   - pip install sphinx sphinx-bootstrap-theme coverage coveralls
   - pip install -e '.[all]' --no-use-wheel
+  - npm install -g jsdoc
 script:
   - flake8 emperor/*.py tests/*.py scripts/*.py setup.py
   - gjslint emperor/support_files/js/*.js tests/javascript_tests/*.js
@@ -27,5 +28,6 @@ script:
   # we just check coverage in the latest version of NumPy
   - if [ ${WITH_COVERAGE} ]; then nosetests emperor --with-coverage --cover-package=emperor --cover-inclusive tests; fi
   - make -C doc html
+  - jsdoc emperor/support_files/js/ -d doc/jsdoc -c jsdoc-config.json -r
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - npm install -g jsdoc
 script:
   - flake8 emperor/*.py tests/*.py scripts/*.py setup.py
-  - gjslint emperor/support_files/js/*.js tests/javascript_tests/*.js
+  - gjslint --custom_jsdoc_tags module,function,constructs emperor/support_files/js/*.js tests/javascript_tests/*.js
   # execute the full test suite
   - python tests/all_tests.py
   # we just check coverage in the latest version of NumPy

--- a/jsdoc-config.json
+++ b/jsdoc-config.json
@@ -1,0 +1,17 @@
+{
+    "tags": {
+        "allowUnknownTags": false,
+        "dictionaries": ["closure"]
+    },
+    "source": {
+        "includePattern": ".+\\.js(doc)?$",
+        "excludePattern": "(^|\\/|\\\\)_"
+    },
+    "plugins": ["plugins/markdown",
+                "plugins/summarize",
+                "plugins/underscore"],
+    "templates": {
+        "cleverLinks": true,
+        "monospaceLinks": true
+    }
+}

--- a/jsdoc-config.json
+++ b/jsdoc-config.json
@@ -1,17 +1,19 @@
 {
     "tags": {
         "allowUnknownTags": false,
-        "dictionaries": ["closure"]
+        "dictionaries": ["closure", "jsdoc"]
     },
     "source": {
         "includePattern": ".+\\.js(doc)?$",
         "excludePattern": "(^|\\/|\\\\)_"
     },
     "plugins": ["plugins/markdown",
-                "plugins/summarize",
                 "plugins/underscore"],
     "templates": {
         "cleverLinks": true,
         "monospaceLinks": true
+    },
+    "opts": {
+        "recurse": true
     }
 }


### PR DESCRIPTION
This adds gjslint and jsdoc runs to travis to make sure new files are styled properly and have parseable docstrings.

TODO: make the documentation link in the docs index point to both the sphinx and jsdoc created documents.