### PR TITLE
ENH: Improve axes labels font size

### DIFF
--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -87,19 +87,24 @@ define(['underscore', 'three'], function(_, THREE) {
    * @param {string} text with the text to be shown on screen.
    * @param {integer} Color Hexadecimal base that represents the color of
    * the text.
+   * @param {float} [1] factor An optional scaling factor to determine the size
+   * of the labels.
    *
    * @return {THREE.Sprite} Object with the text displaying in it.
    * @function makeLabel
    **/
-  function makeLabel(position, text, color) {
+  function makeLabel(position, text, color, factor) {
     var canvas = document.createElement('canvas');
     var size = 512;
+
+    factor = (factor === undefined ? 1 : factor);
+
     canvas.width = size;
     canvas.height = size;
     var context = canvas.getContext('2d');
     context.fillStyle = '#ffffff';
     context.textAlign = 'center';
-    context.font = '30px Arial';
+    context.font = (30 * factor) + 'px Arial';
     context.fillText(text, size / 2, size / 2);
 
     var amap = new THREE.Texture(canvas);

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -327,7 +327,9 @@ define([
    *
    */
   ScenePlotView3D.prototype.drawAxesLabelsWithColor = function(color) {
-    var scope = this, axisLabel, decomp, firstKey, text;
+    var scope = this, axisLabel, decomp, firstKey, text, factor;
+
+    factor = (this.dimensionRanges.max[0] - this.dimensionRanges.min[0]) * 0.9;
 
     this.removeAxesLabels();
 
@@ -343,7 +345,7 @@ define([
       text = decomp.abbreviatedName + ' (' +
              decomp.percExpl[index].toPrecision(4) + ' %)';
 
-      axisLabel = makeLabel(end, text, color);
+      axisLabel = makeLabel(end, text, color, factor);
       axisLabel.name = scope._axisLabelPrefix + index;
 
       scope.scene.add(axisLabel);

--- a/tests/javascript_tests/test_draw.js
+++ b/tests/javascript_tests/test_draw.js
@@ -57,7 +57,7 @@ requirejs(['draw'], function(draw) {
 
     /**
      *
-     * Test that makeLabel works correctly.
+     * Test that makeLabel works correctly without a factor
      *
      */
     test('Test makeLabel works correctly', function(assert) {
@@ -72,6 +72,22 @@ requirejs(['draw'], function(draw) {
       equal(label.position.z, 0);
     });
 
+    /**
+     *
+     * Test that makeLabel works correctly with a factor.
+     *
+     */
+    test('Test makeLabel works correctly', function(assert) {
+      var label = makeLabel([0, 0, 0], 'foolibusters', 0xFFFF00, 20);
+
+      equal(label.material.color.r, 1);
+      equal(label.material.color.g, 1);
+      equal(label.material.color.b, 0);
+
+      equal(label.position.x, 0);
+      equal(label.position.y, 0);
+      equal(label.position.z, 0);
+    });
 
     /**
      *


### PR DESCRIPTION
The size of the font in the axes labels is now determined according to
the range of the datapoints (like with the sphere sizes).