### PR TITLE
ENH: Add support to plot 🐼s DataFrame objects

### DIFF
--- a/doc/source/emperor_objects.rst
+++ b/doc/source/emperor_objects.rst
@@ -1,1 +1,4 @@
-.. automodule:: emperor.core
+Emperor's public API
+====================
+
+.. automodule:: emperor

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -28,7 +28,7 @@ Format Description:
 Citing Emperor
 ==============
 
-Remember to cite Emperor If you use it in any published research, please
+Remember to cite Emperor if you use it in any published research, please
 include the following citation:
 
 .. note::

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,26 +9,7 @@ Emperor's Documentation
 Emperor is an interactive next generation tool for the analysis, visualization
 and understanding of high throughput microbial ecology datasets.
 
-This section of the documentation describes the usage of Emperor's main command
-line interface `make_emperor.py`.
-
 The :ref:`genindex` lists the contents of this documentation.
-
-Citing Emperor
-==============
-
-Remember to cite Emperor If you use it in any published research, please
-include the following citation:
-
-.. note::
-	**EMPeror: a tool for visualizing high-throughput microbial community data**. Vazquez-Baeza Y, Pirrung M, Gonzalez A, Knight R. Gigascience. 2013 Nov 26;2(1):16.
-
-
-You can find the `Emperor paper here <http://www.gigasciencejournal.com/content/2/1/16/>`_, and the data presented in this paper can be found `here <http://gigadb.org/dataset/100068>`_.
-
-
-Classes:
-========
 
 .. toctree::
    :maxdepth: 4
@@ -43,3 +24,15 @@ Format Description:
 
    formats
 
+
+Citing Emperor
+==============
+
+Remember to cite Emperor If you use it in any published research, please
+include the following citation:
+
+.. note::
+	**EMPeror: a tool for visualizing high-throughput microbial community data**. Vazquez-Baeza Y, Pirrung M, Gonzalez A, Knight R. Gigascience. 2013 Nov 26;2(1):16.
+
+
+You can find the `Emperor paper here <http://www.gigasciencejournal.com/content/2/1/16/>`_, and the data presented in this paper can be found `here <http://gigadb.org/dataset/100068>`_.

--- a/emperor/__init__.py
+++ b/emperor/__init__.py
@@ -8,5 +8,7 @@
 __version__ = "0.9.51-dev"  # noqa
 
 from emperor.core import Emperor
+from emperor.pandas import scatterplot
 
-__all__ = ['Emperor', 'biplots', 'format', 'filter', 'parse', 'sort', 'util']
+__all__ = ['Emperor', 'scatterplot', 'biplots', 'format', 'filter', 'parse',
+           'sort', 'util']

--- a/emperor/__init__.py
+++ b/emperor/__init__.py
@@ -2,8 +2,8 @@ r"""
 Emperor 3D PCoA viewer (:mod:`emperor`)
 ============================================
 
-This module provides an objects and functions to interact and visualize a set
-of coordinates using the Emperor interface user interface. The `Emperor` class,
+This module provides objects and functions to interact and visualize a set of
+coordinates using the Emperor interface user interface. The `Emperor` class,
 and the functions present here are all intended to be compatible with the
 Jupyter notebook.
 

--- a/emperor/__init__.py
+++ b/emperor/__init__.py
@@ -1,3 +1,29 @@
+r"""
+Emperor 3D PCoA viewer (:mod:`emperor`)
+============================================
+
+This module provides an objects and functions to interact and visualize a set
+of coordinates using the Emperor interface user interface. The `Emperor` class,
+and the functions present here are all intended to be compatible with the
+Jupyter notebook.
+
+.. currentmodule:: emperor
+
+Classes
+-------
+.. autosummary::
+    :toctree: generated/
+
+    Emperor
+
+Functions
+---------
+.. autosummary::
+    :toctree: generated/
+
+    nbinstall
+    scatterplot
+"""
 # ----------------------------------------------------------------------------
 # Copyright (c) 2013--, emperor development team.
 #
@@ -8,7 +34,8 @@
 __version__ = "0.9.51-dev"  # noqa
 
 from emperor.core import Emperor
-from emperor.pandas import scatterplot
+from emperor._pandas import scatterplot
+from emperor.util import nbinstall
 
 __all__ = ['Emperor', 'scatterplot', 'biplots', 'format', 'filter', 'parse',
-           'sort', 'util']
+           'sort', 'util', 'nbinstall']

--- a/emperor/_pandas.py
+++ b/emperor/_pandas.py
@@ -1,19 +1,3 @@
-r"""
-Pandas Interface for Emperor
-============================
-
-This module provides a simple interface to visualize a Pandas DataFrame using
-the Emperor.
-
-.. currentmodule:: emperor.pandas
-
-Functions
----------
-.. autosummary::
-    :toctree: generated/
-
-    scatterplot
-"""
 # ----------------------------------------------------------------------------
 # Copyright (c) 2013--, emperor development team.
 #

--- a/emperor/_pandas.py
+++ b/emperor/_pandas.py
@@ -20,14 +20,15 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
     Parameters
     ----------
     df : pd.DataFrame
-        Pandas DataFrame with the data to display
+        Pandas DataFrame with the data to display, this includes both
+        *metadata* and coordinates to position the samples in a 3D space.
     x, y, z : str, optional
         Column names in `df`, to use as first (``x``), second (``y``) and third
-        (``z``) axes in the visualization. If these are not specified, axers
+        (``z``) axes in the visualization. If these are not specified, axes
         are chosen according to the variance (in decremental order).
-    remote : bool
+    remote : bool, optional
         Whether the JavaScript resources should be loaded locally or from
-        GitHub
+        GitHub. Defaults to ``True``.
 
     Returns
     -------

--- a/emperor/_pandas.py
+++ b/emperor/_pandas.py
@@ -21,7 +21,7 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
     ----------
     df : pd.DataFrame
         Pandas DataFrame with the data to display, this includes both
-        *metadata* and coordinates to position the samples in a 3D space.
+        *metadata* and *coordinates* to position the samples in a 3D space.
     x, y, z : str, optional
         Column names in `df`, to use as first (``x``), second (``y``) and third
         (``z``) axes in the visualization. If these are not specified, axes
@@ -47,7 +47,7 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
 
     Notes
     -----
-    If a row has missing data, that data pont will be removed from the
+    If a row has missing data, that data point will be removed from the
     visualization.
 
     See Also

--- a/emperor/_pandas.py
+++ b/emperor/_pandas.py
@@ -77,7 +77,7 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
 
     # sort columns by variance
     variance = samples.var().sort_values(ascending=False)
-    samples = samples[variance.index].copy()
+    samples = samples[variance.index]
 
     # re-order x, y and z
     ordered = samples.columns.tolist()
@@ -85,10 +85,10 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
         if col is not None:
             ordered.remove(col)
             ordered = [col] + ordered
-    samples = samples[ordered].copy()
+    samples = samples[ordered]
 
     # match up the metadata and coordinates
-    df = df.loc[samples.index].copy()
+    df = df.loc[samples.index]
 
     ores = OrdinationResults(short_method_name='', long_method_name='',
                              eigvals=np.zeros_like(samples.columns),

--- a/emperor/core.py
+++ b/emperor/core.py
@@ -273,6 +273,7 @@ class Emperor(object):
         d = self.dimensions
         pct_var = (self.ordination.proportion_explained[:d] * 100).tolist()
         coords = self.ordination.samples.values[:, :d].tolist()
+        names = self.ordination.samples.columns[:d].tolist()
 
         # avoid unicode strings
         coord_ids = list(map(str, self.mf.index.tolist()))
@@ -287,6 +288,7 @@ class Emperor(object):
                                     metadata=metadata, base_url=self.base_url,
                                     plot_id=plot_id,
                                     logic_template_path=basename(LOGIC_PATH),
-                                    style_template_path=basename(STYLE_PATH))
+                                    style_template_path=basename(STYLE_PATH),
+                                    axes_names=names)
 
         return plot

--- a/emperor/pandas.py
+++ b/emperor/pandas.py
@@ -39,8 +39,8 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
         Pandas DataFrame with the data to display
     x, y, z : str, optional
         Column names in `df`, to use as first (``x``), second (``y``) and third
-        (``z``) axes. If these are not specified, axers are chosen according
-        to the variance (in decremental order).
+        (``z``) axes in the visualization. If these are not specified, axers
+        are chosen according to the variance (in decremental order).
     remote : bool
         Whether the JavaScript resources should be loaded locally or from
         GitHub

--- a/emperor/pandas.py
+++ b/emperor/pandas.py
@@ -42,19 +42,22 @@ def scatterplot(df, x=None, y=None, z=None):
     if not isinstance(df, pd.DataFrame):
         raise ValueError("The argument is not a Pandas DataFrame")
 
-    cols = []
-    for col in [x, y, z]:
+    ordered = df.columns.tolist()
+    for col in [z, y, x]:
         if col is None:
             continue
-
-        if col is not None:
-            cols.append(col)
 
         if col not in df.columns:
             raise ValueError("'%s' is not a column in the DataFrame" % col)
 
         if not np.issubdtype(df[col].dtype, np.number):
             raise ValueError("'%s' is not a numeric column" % col)
+
+        # re-order x, y and z
+        ordered.remove(col)
+        ordered = [col] + ordered
+
+    df = df[ordered].copy()
 
     samples = df.select_dtypes(include=[np.number]).copy()
     samples.dropna(axis=0, how='any', inplace=True)

--- a/emperor/pandas.py
+++ b/emperor/pandas.py
@@ -86,8 +86,8 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
     samples = df.select_dtypes(include=[np.number]).copy()
     samples.dropna(axis=0, how='any', inplace=True)
 
-    if len(samples) < 3:
-        raise ValueError("Not enough rows without missing data")
+    if len(samples.columns) < 3:
+        raise ValueError("Not enough data to plot")
 
     # sort columns by variance
     variance = samples.var().sort_values(ascending=False)

--- a/emperor/pandas.py
+++ b/emperor/pandas.py
@@ -37,9 +37,10 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
     ----------
     df : pd.DataFrame
         Pandas DataFrame with the data to display
-    x, y, z : str
-        Column names in `df`, these will represent the order of the axes in the
-        final visualization.
+    x, y, z : str, optional
+        Column names in `df`, to use as first (``x``), second (``y``) and third
+        (``z``) axes. If these are not specified, axers are chosen according
+        to the variance (in decremental order).
     remote : bool
         Whether the JavaScript resources should be loaded locally or from
         GitHub

--- a/emperor/pandas.py
+++ b/emperor/pandas.py
@@ -105,7 +105,7 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
     # match up the metadata and coordinates
     df = df.loc[samples.index].copy()
 
-    ores = OrdinationResults(short_method_name='Ax', long_method_name='Axis',
+    ores = OrdinationResults(short_method_name='', long_method_name='',
                              eigvals=np.zeros_like(samples.columns),
                              samples=samples, proportion_explained=variance)
 

--- a/emperor/pandas.py
+++ b/emperor/pandas.py
@@ -30,19 +30,42 @@ from emperor.core import Emperor
 from skbio import OrdinationResults
 
 
-def scatterplot(df, x=None, y=None, z=None):
-    """
+def scatterplot(df, x=None, y=None, z=None, remote=True):
+    """Create an Emperor scatter plot from a Pandas DataFrame
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Pandas DataFrame with the data to display
+    x, y, z : str
+        Column names in `df`, these will represent the order of the axes in the
+        final visualization.
+    remote : bool
+        Whether the JavaScript resources should be loaded locally or from
+        GitHub
+
+    Raises
+    ------
+    ValueError
+        If `df` is not a PandasDataFrame
+        If `x`, `y` or `z` are missing from `df` or if they are not numeric
+        columns.
+        If after removing rows with missing data there are fewer than 3
+        samples.
 
     Notes
     -----
     If a row has missing data, that data pont will be removed from the
-    visualizaiton.
+    visualization.
+
+    See Also
+    --------
+    emperor.core.Emperor
     """
 
     if not isinstance(df, pd.DataFrame):
         raise ValueError("The argument is not a Pandas DataFrame")
 
-    ordered = df.columns.tolist()
     for col in [z, y, x]:
         if col is None:
             continue
@@ -53,22 +76,26 @@ def scatterplot(df, x=None, y=None, z=None):
         if not np.issubdtype(df[col].dtype, np.number):
             raise ValueError("'%s' is not a numeric column" % col)
 
-        # re-order x, y and z
-        ordered.remove(col)
-        ordered = [col] + ordered
-
-    df = df[ordered].copy()
-
+    # remove NAs
     samples = df.select_dtypes(include=[np.number]).copy()
     samples.dropna(axis=0, how='any', inplace=True)
-
-    variance = samples.var().sort_values(ascending=False)
-
-    samples = samples[variance.index].copy()
 
     if len(samples) < 3:
         raise ValueError("Not enough rows without missing data")
 
+    # sort columns by variance
+    variance = samples.var().sort_values(ascending=False)
+    samples = samples[variance.index].copy()
+
+    # re-order x, y and z
+    ordered = samples.columns.tolist()
+    for col in [z, y, x]:
+        if col is not None:
+            ordered.remove(col)
+            ordered = [col] + ordered
+    samples = samples[ordered].copy()
+
+    # match up the metadata and coordinates
     df = df.loc[samples.index].copy()
 
     ores = OrdinationResults(short_method_name='Ax', long_method_name='Axis',
@@ -77,4 +104,7 @@ def scatterplot(df, x=None, y=None, z=None):
 
     df.index.name = '#SampleID'
 
-    return Emperor(ores, df, dimensions=5)
+    # HACK: scale the position of the samples to fit better within the screen
+    ores.samples = ores.samples / ores.samples.max(axis=0)
+
+    return Emperor(ores, df, dimensions=8, remote=remote)

--- a/emperor/pandas.py
+++ b/emperor/pandas.py
@@ -44,6 +44,12 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
         Whether the JavaScript resources should be loaded locally or from
         GitHub
 
+    Returns
+    -------
+    emperor.core.Emperor
+        Emperor object with the numerical data as the `ordination` attribute
+        and the entire DataFrame as the `mf` attribute.
+
     Raises
     ------
     ValueError

--- a/emperor/pandas.py
+++ b/emperor/pandas.py
@@ -1,0 +1,77 @@
+r"""
+Pandas Interface for Emperor
+============================
+
+This module provides a simple interface to visualize a Pandas DataFrame using
+the Emperor.
+
+.. currentmodule:: emperor.pandas
+
+Functions
+---------
+.. autosummary::
+    :toctree: generated/
+
+    scatterplot
+"""
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, emperor development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.md, distributed with this software.
+# ----------------------------------------------------------------------------
+from __future__ import division
+
+import numpy as np
+import pandas as pd
+
+from emperor.core import Emperor
+from skbio import OrdinationResults
+
+
+def scatterplot(df, x=None, y=None, z=None):
+    """
+
+    Notes
+    -----
+    If a row has missing data, that data pont will be removed from the
+    visualizaiton.
+    """
+
+    if not isinstance(df, pd.DataFrame):
+        raise ValueError("The argument is not a Pandas DataFrame")
+
+    cols = []
+    for col in [x, y, z]:
+        if col is None:
+            continue
+
+        if col is not None:
+            cols.append(col)
+
+        if col not in df.columns:
+            raise ValueError("'%s' is not a column in the DataFrame" % col)
+
+        if not np.issubdtype(df[col].dtype, np.number):
+            raise ValueError("'%s' is not a numeric column" % col)
+
+    samples = df.select_dtypes(include=[np.number]).copy()
+    samples.dropna(axis=0, how='any', inplace=True)
+
+    variance = samples.var().sort_values(ascending=False)
+
+    samples = samples[variance.index].copy()
+
+    if len(samples) < 3:
+        raise ValueError("Not enough rows without missing data")
+
+    df = df.loc[samples.index].copy()
+
+    ores = OrdinationResults(short_method_name='Ax', long_method_name='Axis',
+                             eigvals=np.zeros_like(samples.columns),
+                             samples=samples, proportion_explained=variance)
+
+    df.index.name = '#SampleID'
+
+    return Emperor(ores, df, dimensions=5)

--- a/emperor/pandas.py
+++ b/emperor/pandas.py
@@ -114,4 +114,5 @@ def scatterplot(df, x=None, y=None, z=None, remote=True):
     # HACK: scale the position of the samples to fit better within the screen
     ores.samples = ores.samples / ores.samples.max(axis=0)
 
-    return Emperor(ores, df, dimensions=8, remote=remote)
+    return Emperor(ores, df, dimensions=len(ores.samples.columns),
+                   remote=remote)

--- a/emperor/support_files/js/model.js
+++ b/emperor/support_files/js/model.js
@@ -121,7 +121,7 @@ function($, _) {
    *
    */
   function DecompositionModel(name, ids, coords, pct_var, md_headers,
-                              metadata) {
+                              metadata, axes_names) {
     var num_coords;
     /**
      * Abbreviated name of the ordination method used to create the data.
@@ -143,6 +143,11 @@ function($, _) {
      * @type {string[]}
      */
     this.md_headers = md_headers;
+    /**
+     * Names of the axes in the ordination
+     * @type {string[]}
+     */
+    this.axesNames = axesNames === undefined ? [] : axesNames;
 
     /*
       Check that the number of coordinates set provided are the same as the

--- a/emperor/support_files/js/model.js
+++ b/emperor/support_files/js/model.js
@@ -121,7 +121,7 @@ function($, _) {
    *
    */
   function DecompositionModel(name, ids, coords, pct_var, md_headers,
-                              metadata, axes_names) {
+                              metadata, axesNames) {
     var num_coords;
     /**
      * Abbreviated name of the ordination method used to create the data.

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -342,15 +342,15 @@ define([
     this._dimensionsIterator(function(start, end, index) {
 
       // construct a label of the format: AbbNam (xx.xx %)
-      if ( decomp.abbreviatedName !== '' ){
+      if (decomp.abbreviatedName !== '') {
         text = decomp.abbreviatedName;
       }
       else {
         // when the labels get too long, it's a bit hard to look at
-        if (decomp.axesNames[index].length > 25){
+        if (decomp.axesNames[index].length > 25) {
           text = decomp.axesNames[index].slice(0, 20) + '...';
         }
-        else{
+        else {
           text = decomp.axesNames[index];
         }
       }

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -342,11 +342,17 @@ define([
     this._dimensionsIterator(function(start, end, index) {
 
       // construct a label of the format: AbbNam (xx.xx %)
-      if ( decomp.axesNames.length === 0 ){
+      if ( decomp.abbreviatedName !== '' ){
         text = decomp.abbreviatedName;
       }
       else {
-        text = decomp.axesNames[index];
+        // when the labels get too long, it's a bit hard to look at
+        if (decomp.axesNames[index].length > 25){
+          text = decomp.axesNames[index].slice(0, 20) + '...';
+        }
+        else{
+          text = decomp.axesNames[index];
+        }
       }
       text += ' (' + decomp.percExpl[index].toPrecision(4) + ' %)';
 

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -340,8 +340,13 @@ define([
     this._dimensionsIterator(function(start, end, index) {
 
       // construct a label of the format: AbbNam (xx.xx %)
-      text = decomp.abbreviatedName + ' (' +
-             decomp.percExpl[index].toPrecision(4) + ' %)';
+      if ( decomp.axesNames.length === 0 ){
+        text = decomp.abbreviatedName;
+      }
+      else {
+        text = decomp.axesNames[index];
+      }
+      text += ' (' + decomp.percExpl[index].toPrecision(4) + ' %)';
 
       axisLabel = makeLabel(end, text, color);
       axisLabel.name = scope._axisLabelPrefix + index;

--- a/emperor/support_files/templates/logic-template.html
+++ b/emperor/support_files/templates/logic-template.html
@@ -94,13 +94,14 @@ function($, model, EmperorController) {
   var pct_var = {{ pct_var | map('float') | list }};
   var md_headers = {{ md_headers}};
   var metadata = {{  metadata }};
+  var axesNames = {{ axes_names }};
 
   var dm, ec;
 
   function init() {
     // Initialize the DecompositionModel
     dm = new DecompositionModel(name, ids, coords, pct_var,
-                                md_headers, metadata);
+                                md_headers, metadata, axesNames);
     // Initialize the EmperorController
     ec = new EmperorController(dm, '{{ plot_id }}');
   }

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ Vazquez-Baeza Y, Pirrung M, Gonzalez A, Knight R.
 Gigascience. 2013 Nov 26;2(1):16.
 """
 
-base = {"numpy >= 1.7", "scipy >= 0.17.0", "click", "pandas"
+base = {"numpy >= 1.7", "scipy >= 0.17.0", "click", "pandas",
         "scikit-bio >= 0.4.0, < 0.5.0", "jinja2", "future"}
 doc = {"Sphinx >= 1.2.2", "sphinx-bootstrap-theme"}
 test = {"nose >= 0.10.1", "pep8", "flake8"}

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ Vazquez-Baeza Y, Pirrung M, Gonzalez A, Knight R.
 Gigascience. 2013 Nov 26;2(1):16.
 """
 
-base = {"numpy >= 1.7", "scipy >= 0.17.0", "click",
+base = {"numpy >= 1.7", "scipy >= 0.17.0", "click", "pandas"
         "scikit-bio >= 0.4.0, < 0.5.0", "jinja2", "future"}
 doc = {"Sphinx >= 1.2.2", "sphinx-bootstrap-theme"}
 test = {"nose >= 0.10.1", "pep8", "flake8"}

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -357,3 +357,21 @@ function($, model, EmperorController) {
 </script>
   </body>
 </html>"""
+
+
+MAP_PANDAS = """#SampleID	cat_a	cat_b	cat_c	num_1	num_2	num_3	num_4
+s1	foo	a	o	21	18	75	51
+s2	foo	b	p	3	42	44	36
+s3	bar	c	q	53	70	5	78
+s4	baz	d	r	47	13	72	72
+s5	FOO	e	s	13	50	1	56
+s6	FOO	f	o	13	56	39	5
+s7	foo	g	o	77	17	26	64
+s8	barosaurus	h	o	63	20	74	69
+s9	baz	i	p	20	32	39	16
+s10	baz	j	p	19	44	61	17
+s11	baz	k	q	47	25	37	42
+s12	baz	l	r	50	73	27	58
+s13	asdf	m	s	11	36	41	32
+s14	1234	n	s	9	32	42	25
+"""

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -165,13 +165,14 @@ function($, model, EmperorController) {
   var pct_var = [26.6887048633, 16.256370402199998, 13.775412916099999, 11.217215823, 10.024774995000001];
   var md_headers = ['SampleID', 'Treatment', 'DOB', 'Description'];
   var metadata = [['PC.636', 'Fast', '20080116', 'Fasting_mouse_I.D._636'], ['PC.635', 'Fast', '20080116', 'Fasting_mouse_I.D._635'], ['PC.356', 'Control', '20061126', 'Control_mouse_I.D._356'], ['PC.481', 'Control', '20070314', 'Control_mouse_I.D._481'], ['PC.354', 'Control', '20061218', 'Ctrol_mouse_I.D._354'], ['PC.593', 'Control', '20071210', 'Control_mouse_I.D._593'], ['PC.355', 'Control', '20061218', 'Control_mouse_I.D._355'], ['PC.607', 'Fast', '20071112', 'Fasting_mouse_I.D._607'], ['PC.634', 'Fast', '20080116', 'Fasting_mouse_I.D._634']];
+  var axesNames = [0, 1, 2, 3, 4];
 
   var dm, ec;
 
   function init() {
     // Initialize the DecompositionModel
     dm = new DecompositionModel(name, ids, coords, pct_var,
-                                md_headers, metadata);
+                                md_headers, metadata, axesNames);
     // Initialize the EmperorController
     ec = new EmperorController(dm, 'emperor-notebook-0x9cb72f54');
   }
@@ -328,13 +329,14 @@ function($, model, EmperorController) {
   var pct_var = [26.6887048633, 16.256370402199998, 13.775412916099999, 11.217215823, 10.024774995000001];
   var md_headers = ['SampleID', 'Treatment', 'DOB', 'Description'];
   var metadata = [['PC.636', 'Fast', '20080116', 'Fasting_mouse_I.D._636'], ['PC.635', 'Fast', '20080116', 'Fasting_mouse_I.D._635'], ['PC.356', 'Control', '20061126', 'Control_mouse_I.D._356'], ['PC.481', 'Control', '20070314', 'Control_mouse_I.D._481'], ['PC.354', 'Control', '20061218', 'Ctrol_mouse_I.D._354'], ['PC.593', 'Control', '20071210', 'Control_mouse_I.D._593'], ['PC.355', 'Control', '20061218', 'Control_mouse_I.D._355'], ['PC.607', 'Fast', '20071112', 'Fasting_mouse_I.D._607'], ['PC.634', 'Fast', '20080116', 'Fasting_mouse_I.D._634']];
+  var axesNames = [0, 1, 2, 3, 4];
 
   var dm, ec;
 
   function init() {
     // Initialize the DecompositionModel
     dm = new DecompositionModel(name, ids, coords, pct_var,
-                                md_headers, metadata);
+                                md_headers, metadata, axesNames);
     // Initialize the EmperorController
     ec = new EmperorController(dm, 'emperor-notebook-0x9cb72f54');
   }

--- a/tests/javascript_tests/test_decomposition_model.js
+++ b/tests/javascript_tests/test_decomposition_model.js
@@ -148,6 +148,19 @@ requirejs([
                                          0.140148]);
 
       equal(dm.length, 9, 'Length set correctly');
+      deepEqual(dm.axesNames, []);
+    });
+
+    /**
+     *
+     * Test constructor with custom axesNames
+     *
+     */
+    test('Test axesNames', function() {
+      var names = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+      var dm = new DecompositionModel(name, ids, coords, pct_var, md_headers,
+          metadata, names);
+      deepEqual(dm.axesNames, names, 'Plottable retrieved successfully');
     });
 
     /**

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,42 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, emperor development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.md, distributed with this software.
+# ----------------------------------------------------------------------------
+from __future__ import division
+
+from unittest import TestCase, main
+
+import pandas as pd
+
+from emperor.core import Emperor
+from emperor.pandas import scatterplot
+
+# account for what's allowed in python 2 vs PY3K
+try:
+    from . import _test_core_strings as tcs
+except:
+    import _test_core_strings as tcs
+
+# from http://stackoverflow.com/a/22605281/379593
+import sys
+if sys.version_info[0] < 3:
+    from StringIO import StringIO
+else:
+    from io import StringIO
+
+
+class TopLevelTests(TestCase):
+    def setUp(self):
+        self.df = pd.read_csv(StringIO(tcs.MAP_PANDAS), sep='\t',
+                              index_col='#SampleID')
+
+    def test_scatterplot(self):
+        emp = scatterplot(self.df)
+
+        self.assertTrue(isinstance(emp, Emperor))
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -10,6 +10,7 @@ from __future__ import division
 from unittest import TestCase, main
 
 import pandas as pd
+import numpy as np
 
 from emperor.core import Emperor
 from emperor.pandas import scatterplot
@@ -33,10 +34,72 @@ class TopLevelTests(TestCase):
         self.df = pd.read_csv(StringIO(tcs.MAP_PANDAS), sep='\t',
                               index_col='#SampleID')
 
+        x = np.array([[0.27272727, 0.65384615, 1., 0.24657534],
+                      [0.03896104, 0.46153846, 0.58666667, 0.57534247],
+                      [0.68831169, 1., 0.06666667, 0.95890411],
+                      [0.61038961, 0.92307692, 0.96, 0.17808219],
+                      [0.16883117, 0.71794872, 0.01333333, 0.68493151],
+                      [0.16883117, 0.06410256, 0.52, 0.76712329],
+                      [1., 0.82051282, 0.34666667, 0.23287671],
+                      [0.81818182, 0.88461538, 0.98666667, 0.2739726],
+                      [0.25974026, 0.20512821, 0.52, 0.43835616],
+                      [0.24675325, 0.21794872, 0.81333333, 0.60273973],
+                      [0.61038961, 0.53846154, 0.49333333, 0.34246575],
+                      [0.64935065, 0.74358974, 0.36, 1.],
+                      [0.14285714, 0.41025641, 0.54666667, 0.49315068],
+                      [0.11688312, 0.32051282, 0.56, 0.43835616]])
+        ind = pd.Index(['s1', 's2', 's3', 's4', 's5', 's6', 's7', 's8', 's9',
+                        's10', 's11', 's12', 's13', 's14'], dtype='object',
+                       name='#SampleID')
+        cols = pd.Index(['num_1', 'num_4', 'num_3', 'num_2'], dtype='object')
+        self.samples = pd.DataFrame(data=x, index=ind, columns=cols)
+
     def test_scatterplot(self):
         emp = scatterplot(self.df)
 
         self.assertTrue(isinstance(emp, Emperor))
+        self.assertEqual(emp.dimensions, 4)
+        self.assertEqual(emp.base_url, 'https://cdn.rawgit.com/biocore/'
+                         'emperor/new-api/emperor/support_files')
+
+        pd.util.testing.assert_frame_equal(self.df, emp.mf)
+
+        pd.util.testing.assert_frame_equal(emp.ordination.samples,
+                                           self.samples)
+
+    def test_scatterplot_reordered(self):
+        emp = scatterplot(self.df, x='num_3', y='num_2', z='num_1')
+
+        self.assertTrue(isinstance(emp, Emperor))
+        self.assertEqual(emp.dimensions, 4)
+        self.assertEqual(emp.base_url, 'https://cdn.rawgit.com/biocore/'
+                         'emperor/new-api/emperor/support_files')
+
+        pd.util.testing.assert_frame_equal(self.df, emp.mf)
+
+        reordered = self.samples[['num_3', 'num_2', 'num_1', 'num_4']].copy()
+
+        pd.util.testing.assert_frame_equal(emp.ordination.samples,
+                                           reordered)
+
+    def test_bad_column_names(self):
+        np.testing.assert_raises(ValueError, scatterplot, self.df, x=':L')
+        np.testing.assert_raises(ValueError, scatterplot, self.df, x='num_1',
+                                 y='column', z='McColumnFace')
+
+    def test_bad_data(self):
+        no_numeric = self.df.select_dtypes(include=['object']).copy()
+
+        np.testing.assert_raises(ValueError, scatterplot, no_numeric)
+
+    def test_bad_non_numeric_columns(self):
+        np.testing.assert_raises(ValueError, scatterplot, self.df, x='cat_a')
+
+    def test_no_dataframe(self):
+        np.testing.assert_raises(ValueError, scatterplot, None)
+        np.testing.assert_raises(ValueError, scatterplot, 1)
+        np.testing.assert_raises(ValueError, scatterplot, 'DataMcDataface')
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -13,7 +13,7 @@ import pandas as pd
 import numpy as np
 
 from emperor.core import Emperor
-from emperor.pandas import scatterplot
+from emperor._pandas import scatterplot
 
 # account for what's allowed in python 2 vs PY3K
 try:


### PR DESCRIPTION
This PR adds a helper function, `scatterplot`, that can take as only argument a
Pandas DataFrame and returns an Emperor object. The function itself
extracts the numerical data from the DataFrame and creates a dummy
OrdinationResults object.

Note that this is a rather experimental feature, so testing/suggestions are
very welcome.

This PR depends on #516 so merge that PR first.