### PR TITLE
BUG: Disable arrow keys from the OrbitControl object

### DIFF
--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -112,9 +112,7 @@ define([
      */
     this.control = new THREE.OrbitControls(this.camera,
                                            $container.get(0));
-    this.control.addEventListener('change', function() {
-      scope.needsUpdate = true;
-    });
+    this.control.enableKeys = false;
     this.control.rotateSpeed = 1.0;
     this.control.zoomSpeed = 1.2;
     this.control.panSpeed = 0.8;
@@ -122,6 +120,10 @@ define([
     this.control.enablePan = true;
     this.control.enableDamping = true;
     this.control.dampingFactor = 0.3;
+    this.control.addEventListener('change', function() {
+      scope.needsUpdate = true;
+    });
+    this.control.update();
     /**
      * True when changes have occured that require re-rendering of the canvas
      * @type {Boolean}


### PR DESCRIPTION
When editing text in the notebook and using the arrows to navigate, the
OrbitControl object would listen to those events and pan the plot around.