### PR TITLE
Flipping bug 🐞

### DIFF
--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -354,7 +354,8 @@ define([
   AxesController.prototype.updateVisibleAxes = function(index, position) {
     // update all the visible dimensions
     _.each(this.decompViewDict, function(decView, key) {
-      var visibleDimensions = decView.visibleDimensions;
+      // clone to avoid indirectly modifying by reference
+      var visibleDimensions = _.clone(decView.visibleDimensions);
 
       visibleDimensions[position] = index;
       decView.changeVisibleDimensions(visibleDimensions);

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -266,7 +266,10 @@ define([
       // update the dimensions that changed.
 
       // if we have to compute the data, clean up the previously known ranges
-      this.dimensionRanges = {'min': [], 'max': []};
+      this.dimensionRanges.max = [];
+      this.dimensionRanges.max.length = 0;
+      this.dimensionRanges.min = [];
+      this.dimensionRanges.min.length = 0;
     }
 
     _.each(this.decViews, function(decView, name) {

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -264,6 +264,7 @@ define([
     else {
       // TODO: If this entire function ever becomes a bottleneck we should only
       // update the dimensions that changed.
+      // See: https://github.com/biocore/emperor/issues/526
 
       // if we have to compute the data, clean up the previously known ranges
       this.dimensionRanges.max = [];

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -262,6 +262,9 @@ define([
       return;
     }
     else {
+      // TODO: If this entire function ever becomes a bottleneck we should only
+      // update the dimensions that changed.
+
       // if we have to compute the data, clean up the previously known ranges
       this.dimensionRanges = {'min': [], 'max': []};
     }

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -236,7 +236,7 @@ define([
       _.each(this.decViews, function(decView, name) {
         var decomp = decView.decomp;
 
-        for (var i = 0; i < decomp.dimensionRanges.max.length; i++){
+        for (var i = 0; i < decomp.dimensionRanges.max.length; i++) {
           // global
           var gMax = scope.dimensionRanges.max[i];
           var gMin = scope.dimensionRanges.min[i];
@@ -248,7 +248,7 @@ define([
           // when we detect a point outside the global ranges we break and
           // recompute them
           if (!(gMin <= lMin && lMin <= gMax) ||
-              !(gMin <= lMax && lMax <= gMax)){
+              !(gMin <= lMax && lMax <= gMax)) {
             computeRanges = true;
             break;
           }
@@ -535,7 +535,7 @@ define([
       this.control.update();
     }
 
-    if (updateData){
+    if (updateData) {
       this.drawAxesWithColor(this.axesColor);
       this.drawAxesLabelsWithColor(this.axesColor);
     }

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -225,11 +225,45 @@ define([
    *
    */
   ScenePlotView3D.prototype._unionRanges = function() {
-    var scope = this;
+    var scope = this, computeRanges;
 
-    // means we already have the data, so let's say goodbye
-    if (this.dimensionRanges.max.length !== 0) {
+    // first check if there's any range data, if there isn't, then we need
+    // to compute it by looking at all the decompositions
+    computeRanges = scope.dimensionRanges.max.length === 0;
+
+    // if there's range data then check it lies within the global ranges
+    if (computeRanges === false) {
+      _.each(this.decViews, function(decView, name) {
+        var decomp = decView.decomp;
+
+        for (var i = 0; i < decomp.dimensionRanges.max.length; i++){
+          // global
+          var gMax = scope.dimensionRanges.max[i];
+          var gMin = scope.dimensionRanges.min[i];
+
+          // local
+          var lMax = decomp.dimensionRanges.max[i];
+          var lMin = decomp.dimensionRanges.min[i];
+
+          // when we detect a point outside the global ranges we break and
+          // recompute them
+          if (!(gMin <= lMin && lMin <= gMax) ||
+              !(gMin <= lMax && lMax <= gMax)){
+            computeRanges = true;
+            break;
+          }
+        }
+      });
+    }
+
+    if (computeRanges === false) {
+      // If at this point we still don't need to compute the data, it is safe
+      // to exit because all data still exists within the expected ranges
       return;
+    }
+    else {
+      // if we have to compute the data, clean up the previously known ranges
+      this.dimensionRanges = {'min': [], 'max': []};
     }
 
     _.each(this.decViews, function(decView, name) {
@@ -493,6 +527,11 @@ define([
     // update, it's an equivalent to asking for re-rendering
     if (this.control.autoRotate) {
       this.control.update();
+    }
+
+    if (updateData){
+      this.drawAxesWithColor(this.axesColor);
+      this.drawAxesLabelsWithColor(this.axesColor);
     }
 
     // if anything has changed, then trigger an update

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -143,12 +143,14 @@ DecompositionView.prototype.changeVisibleDimensions = function(newDims) {
       var index = this.visibleDimensions[i],
           orientation = this.axesOrientation[i];
 
-      // 1.- Correct the range of the ranges for the dimension that we are
+      // 1.- Correct the limits of the ranges for the dimension that we are
       // moving out of the scene i.e. the old dimension
-      var newMin = this.decomp.dimensionRanges.max[index] *= orientation;
-      var newMax = this.decomp.dimensionRanges.min[index] *= orientation;
-      this.decomp.dimensionRanges.max[index] = newMax;
-      this.decomp.dimensionRanges.min[index] = newMin;
+      if (this.axesOrientation[i] === -1) {
+        var max = this.decomp.dimensionRanges.max[index];
+        var min = this.decomp.dimensionRanges.min[index];
+        this.decomp.dimensionRanges.max[index] = min * (-1);
+        this.decomp.dimensionRanges.min[index] = max * (-1);
+      }
 
       // 2.- Set the orientation of the new dimension to be 1
       this.axesOrientation[i] = 1;
@@ -186,20 +188,21 @@ DecompositionView.prototype.changeVisibleDimensions = function(newDims) {
 DecompositionView.prototype.flipVisibleDimension = function(index) {
   var pos, scope = this, newMin, newMax;
 
-  index = this.visibleDimensions.indexOf(index);
+  // the index in the visible dimensions
+  var localIndex = this.visibleDimensions.indexOf(index);
 
-  if (index !== -1) {
+  if (localIndex !== -1) {
     var x = this.visibleDimensions[0], y = this.visibleDimensions[1],
         z = this.visibleDimensions[2];
 
     // update the ranges for this decomposition
-    newMin = this.decomp.dimensionRanges.max[index] *= -1;
-    newMax = this.decomp.dimensionRanges.min[index] *= -1;
-    this.decomp.dimensionRanges.max[index] = newMax;
-    this.decomp.dimensionRanges.min[index] = newMin;
+    var max = this.decomp.dimensionRanges.max[index];
+    var min = this.decomp.dimensionRanges.min[index];
+    this.decomp.dimensionRanges.max[index] = min * (-1);
+    this.decomp.dimensionRanges.min[index] = max * (-1);
 
     // and update the state of the orientation
-    this.axesOrientation[index] *= -1;
+    this.axesOrientation[localIndex] *= -1;
 
     this.decomp.apply(function(plottable) {
       mesh = scope.markers[plottable.idx];

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -137,7 +137,7 @@ DecompositionView.prototype.changeVisibleDimensions = function(newDims) {
   }
 
   // one by one, find and update the dimensions that are changing
-  for (var i = 0; i < 3; i++){
+  for (var i = 0; i < 3; i++) {
     if (this.visibleDimensions[i] !== newDims[i]) {
       // index represents the global position of the dimension
       var index = this.visibleDimensions[i],

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -153,9 +153,15 @@ DecompositionView.prototype.changeVisibleDimensions = function(newDims) {
  *
  */
 DecompositionView.prototype.flipVisibleDimension = function(index) {
-  var pos, scope = this;
+  var pos, scope = this, newMin, newMax;
 
   index = this.visibleDimensions.indexOf(index);
+
+  // update the ranges for this decomposition
+  newMin = this.decomp.dimensionRanges.max[index] *= -1;
+  newMax = this.decomp.dimensionRanges.min[index] *= -1;
+  this.decomp.dimensionRanges.max[index] = newMax;
+  this.decomp.dimensionRanges.min[index] = newMin;
 
   if (index !== -1) {
     this.decomp.apply(function(plottable) {

--- a/tests/javascript_tests/test_decomposition_view.js
+++ b/tests/javascript_tests/test_decomposition_view.js
@@ -74,6 +74,8 @@ requirejs([
       equal(dv.axesColor, 0xFFFFFF);
       equal(dv.backgroundColor, 0x000000);
 
+      deepEqual(dv.axesOrientation, [1, 1, 1]);
+
       /*
          I'm unsure on how to test this, so right now just testing what I think
          makes sense to test
@@ -114,6 +116,8 @@ requirejs([
       dv.markers[1].position.z];
       exp = [-0.138136, 0.159061, -0.247485];
       deepEqual(obs, exp, 'Second marker position updated correctly');
+
+      deepEqual(dv.axesOrientation, [1, 1, 1]);
     });
 
     /**
@@ -133,26 +137,82 @@ requirejs([
           );
     });
 
-
     /**
      *
      * Test that changeVisibleDimensions updates the meshes position
      *
      */
-    test('Test change flip axes', function() {
+    test('Test change flip axes', function(assert) {
       var dv = new DecompositionView(decomp);
 
-      expa = dv.markers[0].position.toArray();
-      expb = dv.markers[1].position.toArray();
+      // copy the arrays
+      expa = _.clone(dv.markers[0].position.toArray());
+      expb = _.clone(dv.markers[1].position.toArray());
+
+      // flip the orientation of the position
+      expb[1] = expb[1] * -1;
       expa[1] = expa[1] * -1;
+
+      // change the position of the decomposition view and ...
       dv.flipVisibleDimension(1);
+
+      // ... Check for the following things:
+      //
+      // 1.- The position themselves
+      // 2.- The ranges i.e. positions still fall within the dimensionRanges.
+      // 3.- The axis orientation vector
       obs = dv.markers[0].position.toArray();
       deepEqual(obs, expa, 'First marker position updated correctly');
 
-      expb[1] = expb[1] * -1;
+      assert.ok(obs[1] <= dv.decomp.dimensionRanges.max[1],
+                'Falls within range (max)');
+      assert.ok(obs[1] >= dv.decomp.dimensionRanges.min[1],
+                'Falls within range (min)');
+
       obs = dv.markers[1].position.toArray();
       deepEqual(obs, expb, 'Second marker position updated correctly');
+
+      assert.ok(obs[1] <= dv.decomp.dimensionRanges.max[1],
+                'Falls within range (max)');
+      assert.ok(obs[1] >= dv.decomp.dimensionRanges.min[1],
+                'Falls within range (min)');
+
+      deepEqual(dv.axesOrientation, [1, -1, 1]);
     });
 
+    /**
+     *
+     * Test that changeVisibleDimensions and flip axis
+     *
+     */
+    test('Test changing the orientations and then flipping a dimension',
+         function() {
+      var dv = new DecompositionView(decomp);
+
+      deepEqual(dv.axesOrientation, [1, 1, 1]);
+
+      dv.changeVisibleDimensions([2, 3, 4]);
+      obs = dv.markers[0].position.toArray();
+      exp = [0.066647, -0.067711, 0.176070];
+      deepEqual(obs, exp, 'First marker position updated correctly');
+
+      obs = dv.markers[1].position.toArray();
+      exp = [-0.138136, 0.159061, -0.247485];
+      deepEqual(obs, exp, 'Second marker position updated correctly');
+
+      deepEqual(dv.axesOrientation, [1, 1, 1]);
+
+      dv.flipVisibleDimension(3);
+
+      obs = dv.markers[0].position.toArray();
+      exp = [0.066647, 0.067711, 0.176070];
+      deepEqual(obs, exp, 'First marker position updated correctly');
+
+      obs = dv.markers[1].position.toArray();
+      exp = [-0.138136, -0.159061, -0.247485];
+      deepEqual(obs, exp, 'Second marker position updated correctly');
+
+      deepEqual(dv.axesOrientation, [1, -1, 1]);
+    });
   });
 });


### PR DESCRIPTION
In the current version of emperor, if you flip the orientation of one of the axis, you may end up in a situation where the range data lies outside of the current axes. To remediate this, the `dimensionRanges` properties are updated to reflect the new range that the data spans. Additionally, we need to keep track of when an axis is reoriented, so we know when change the ranges back in a situation when we are swapping out a *flipped* dimension.

I've also improved the test cases to reproduce the problem.

-------

This one took longer than I was hoping. 😫 