### PR TITLE
Surgically add the EmperorViewController class

### DIFF
--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -8,7 +8,7 @@ define([
 ], function($, _, DecompositionView, ViewControllers, d3, contextmenu) {
 
   // we only use the base attribute class, no need to get the base class
-  var EmperorViewControllerABC = ViewControllers.EmperorViewControllerABC;
+  var EmperorViewController = ViewControllers.EmperorViewController;
 
   /**
    * @class AxesController
@@ -30,25 +30,8 @@ define([
     var helpmenu = 'Change the visible dimensions of the data';
     var title = 'Axes';
     var scope = this;
-
-    if (decompViewDict === undefined) {
-      throw Error('The decomposition view dictionary cannot be undefined');
-    }
-    for (var dv in decompViewDict) {
-      if (!dv instanceof DecompositionView) {
-        throw Error('The decomposition view dictionary ' +
-            'can only have decomposition views');
-      }
-    }
-    if (_.size(decompViewDict) <= 0) {
-      throw Error('The decomposition view dictionary cannot be empty');
-    }
-    this.decompViewDict = decompViewDict;
-
-    // Picks the first key in the dictionary as the active key
-    this.activeViewKey = Object.keys(decompViewDict)[0];
-
-    EmperorViewControllerABC.call(this, container, title, helpmenu);
+    EmperorViewController.call(this, container, title, helpmenu,
+                               decompViewDict);
 
     var colors = '<table style="width:inherit; border:none;">';
     colors += '<tr><td>Axes and Labels Color</td>';
@@ -132,8 +115,8 @@ define([
 
     return this;
   }
-  AxesController.prototype = Object.create(EmperorViewControllerABC.prototype);
-  AxesController.prototype.constructor = EmperorViewControllerABC;
+  AxesController.prototype = Object.create(EmperorViewController.prototype);
+  AxesController.prototype.constructor = EmperorViewController;
 
   /**
    * Create a table to display the visible axis information.

--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -6,8 +6,6 @@ define([
     'd3',
     'contextmenu'
 ], function($, _, DecompositionView, ViewControllers, d3, contextmenu) {
-
-  // we only use the base attribute class, no need to get the base class
   var EmperorViewController = ViewControllers.EmperorViewController;
 
   /**

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -280,7 +280,7 @@ define([
 
   /**
    *
-   * @class EmperorViewControllerABC
+   * @class EmperorAttributeABC
    *
    * Initializes an abstract tab for attributes i.e. shape, color, size, etc.
    * This has to be contained in a DOM object and will use the full size of

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -186,6 +186,86 @@ define([
     throw Error('Not implemented');
   };
 
+
+  /**
+   *
+   * @class EmperorViewController
+   *
+   * Base class for view controllers that use a dictionary of decomposition
+   * views, but that are not controlled by a metadata category, for those
+   * cases, see `EmperorAttributeABC`.
+   *
+   * @param {Node} container Container node to create the controller in.
+   * @param {String} title title of the tab.
+   * @param {String} description helper description.
+   * @param {Object} decompViewDict This is object is keyed by unique
+   * identifiers and the values are DecompositionView objects referring to a
+   * set of objects presented on screen. This dictionary will usually be shared
+   * by all the tabs in the application. This argument is passed by reference.
+   *
+   * @return {EmperorViewController} Returns an instance of the
+   * EmperorViewController class.
+   * @constructs EmperorViewController
+   * @extends EmperorViewControllerABC
+   *
+   */
+  function EmperorViewController(container, title, description,
+                                 decompViewDict) {
+    EmperorViewControllerABC.call(this, container, title, description);
+    if (decompViewDict === undefined) {
+      throw Error('The decomposition view dictionary cannot be undefined');
+    }
+    for (var dv in decompViewDict) {
+      if (!dv instanceof DecompositionView) {
+        throw Error('The decomposition view dictionary ' +
+            'can only have decomposition views');
+      }
+    }
+    if (_.size(decompViewDict) <= 0) {
+      throw Error('The decomposition view dictionary cannot be empty');
+    }
+    // Picks the first key in the dictionary as the active key
+    /**
+     * @type {String}
+     * This is the key of the active decomposition view.
+     */
+    this.activeViewKey = Object.keys(decompViewDict)[0];
+
+    /**
+     * @type {Object}
+     * This is object is keyed by unique identifiers and the values are
+     * DecompositionView objects referring to a set of objects presented on
+     * screen. This dictionary will usually be shared by all the tabs in the
+     * application. This argument is passed by reference.
+     */
+    this.decompViewDict = decompViewDict;
+
+    return this;
+  }
+  EmperorViewController.prototype = Object.create(
+      EmperorViewControllerABC.prototype);
+  EmperorViewController.prototype.constructor = EmperorViewControllerABC;
+
+  /**
+   * Retrieves the metadata field currently being controlled
+   *
+   * @return {String} A key corresponding to the active decomposition view.
+   */
+  EmperorViewController.prototype.getActiveDecompViewKey = function() {
+    return this.activeViewKey;
+  };
+
+  /**
+   * Changes the metadata column name to control.
+   *
+   * @param {String} k Key corresponding to active decomposition view.
+   */
+  EmperorViewController.prototype.setActiveDecompViewKey = function(k) {
+    // FIXME: this should be validated against decompViewDict i.e. we should be
+    // verifying that the key indeed exists
+    this.activeViewKey = k;
+  };
+
   /**
    *
    * @class EmperorViewControllerABC
@@ -220,39 +300,14 @@ define([
    * @return {EmperorAttributeABC} Returns an instance of the
    * EmperorAttributeABC class.
    * @constructs EmperorAttributeABC
-   * @extends EmperorViewControllerABC
+   * @extends EmperorViewController
    *
    */
   function EmperorAttributeABC(container, title, description,
       decompViewDict, options) {
-    EmperorViewControllerABC.call(this, container, title, description);
-    if (decompViewDict === undefined) {
-      throw Error('The decomposition view dictionary cannot be undefined');
-    }
-    for (var dv in decompViewDict) {
-      if (!dv instanceof DecompositionView) {
-        throw Error('The decomposition view dictionary ' +
-            'can only have decomposition views');
-      }
-    }
-    if (_.size(decompViewDict) <= 0) {
-      throw Error('The decomposition view dictionary cannot be empty');
-    }
-    // Picks the first key in the dictionary as the active key
-    /**
-     * @type {String}
-     * This is the key of the active decomposition view.
-     */
-    this.activeViewKey = Object.keys(decompViewDict)[0];
+    EmperorViewController.call(this, container, title, description,
+                               decompViewDict);
 
-    /**
-     * @type {Object}
-     * This is object is keyed by unique identifiers and the values are
-     * DecompositionView objects referring to a set of objects presented on
-     * screen. This dictionary will usually be shared by all the tabs in the
-     * application. This argument is passed by reference.
-     */
-    this.decompViewDict = decompViewDict;
     /**
      * @type {Node}
      * jQuery element for the div containing the slickgrid of sample information
@@ -301,8 +356,8 @@ define([
     return this;
   }
   EmperorAttributeABC.prototype = Object.create(
-    EmperorViewControllerABC.prototype);
-  EmperorAttributeABC.prototype.constructor = EmperorViewControllerABC;
+    EmperorViewController.prototype);
+  EmperorAttributeABC.prototype.constructor = EmperorViewController;
 
   /**
    * Changes the metadata column name to control.
@@ -314,26 +369,6 @@ define([
     // verifying that the metadata field indeed exists in the decomposition
     // model
     this.metadataField = m;
-  };
-
-  /**
-   * Retrieves the metadata field currently being controlled
-   *
-   * @return {String} A key corresponding to the active decomposition view.
-   */
-  EmperorAttributeABC.prototype.getActiveDecompViewKey = function() {
-    return this.activeViewKey;
-  };
-
-  /**
-   * Changes the metadata column name to control.
-   *
-   * @param {String} k Key corresponding to active decomposition view.
-   */
-  EmperorAttributeABC.prototype.setActiveDecompViewKey = function(k) {
-    // FIXME: this should be validated against decompViewDict i.e. we should be
-    // verifying that the key indeed exists
-    this.activeViewKey = k;
   };
 
   /**
@@ -402,7 +437,7 @@ define([
    */
   EmperorAttributeABC.prototype.resize = function(width, height) {
     // call super, most of the header and body resizing logic is done there
-    EmperorViewControllerABC.prototype.resize.call(this, width, height);
+    EmperorViewController.prototype.resize.call(this, width, height);
 
     // the whole code is asynchronous, so there may be situations where
     // bodyGrid doesn't exist yet, so check before trying to modify the object
@@ -454,5 +489,6 @@ define([
   };
 
   return {'EmperorViewControllerABC': EmperorViewControllerABC,
-    'EmperorAttributeABC': EmperorAttributeABC};
+          'EmperorViewController': EmperorViewController,
+          'EmperorAttributeABC': EmperorAttributeABC};
 });

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -247,7 +247,7 @@ define([
   EmperorViewController.prototype.constructor = EmperorViewControllerABC;
 
   /**
-   * Retrieves the metadata field currently being controlled
+   * Retrieves the name of the currently active decomposition view.
    *
    * @return {String} A key corresponding to the active decomposition view.
    */
@@ -256,14 +256,26 @@ define([
   };
 
   /**
-   * Changes the metadata column name to control.
+   * Changes the currently active decomposition view.
    *
    * @param {String} k Key corresponding to active decomposition view.
+   * @throws {Error} The key must exist, otherwise an exception will be thrown.
    */
   EmperorViewController.prototype.setActiveDecompViewKey = function(k) {
-    // FIXME: this should be validated against decompViewDict i.e. we should be
-    // verifying that the key indeed exists
+    if (this.decompViewDict[k] === undefined) {
+      throw new Error('This key does not exist, "' + k + '" in the ' +
+                      'the decompViewDict.');
+    }
     this.activeViewKey = k;
+  };
+
+  /**
+   * Retrieves the currently active decomposition view.
+   *
+   * @return {DecompositionView} The currently active decomposition view.
+   */
+  EmperorViewController.prototype.getActiveView = function() {
+    return this.decompViewDict[this.getActiveDecompViewKey()];
   };
 
   /**

--- a/tests/javascript_tests/test_view_controller.js
+++ b/tests/javascript_tests/test_view_controller.js
@@ -202,7 +202,7 @@ requirejs([
      * Tests to make sure the exceptions are being raised as expected
      *
      */
-    test('Cosnstructor test exceptions', function(assert) {
+    test('Constructor test exceptions', function(assert) {
       var dv = new DecompositionView(this.decomp);
 
       throws(function() {

--- a/tests/javascript_tests/test_view_controller.js
+++ b/tests/javascript_tests/test_view_controller.js
@@ -233,6 +233,34 @@ requirejs([
 
     /**
      *
+     * Test get active decomposition view key
+     *
+     */
+    test('Test getActiveDecompViewKey exception', function() {
+      var dv = new DecompositionView(this.decomp);
+      var container = $('<div id="does-not-exist"></div>');
+      var attr = new EmperorViewController(container, 'foo', 'bar',
+                                           {'scatter': dv});
+      throws(function() {
+        attr.setActiveDecompViewKey('KeyMcKeyFace');
+      }, Error, 'This key is not presen in the dictionary');
+    });
+
+    /**
+     *
+     * Test the active decomposition view can be correctly retrieved
+     *
+     */
+    test('Test getActiveView', function() {
+      var dv = new DecompositionView(this.decomp);
+      var container = $('<div id="does-not-exist"></div>');
+      var attr = new EmperorViewController(container, 'foo', 'bar',
+                                           {'scatter': dv});
+      deepEqual(attr.getActiveView(), dv);
+    });
+
+    /**
+     *
      * Test set active decomposition view key
      *
      */

--- a/tests/javascript_tests/test_view_controller.js
+++ b/tests/javascript_tests/test_view_controller.js
@@ -7,6 +7,7 @@ requirejs([
     'slickgrid'
 ], function($, _, model, DecompositionView, viewcontroller, SlickGrid) {
   var EmperorViewControllerABC = viewcontroller.EmperorViewControllerABC;
+  var EmperorViewController = viewcontroller.EmperorViewController;
   var EmperorAttributeABC = viewcontroller.EmperorAttributeABC;
   var DecompositionModel = model.DecompositionModel;
 
@@ -133,6 +134,117 @@ requirejs([
       }, Error, 'Cannot call this abstract method');
     });
 
+    module('EmperorViewController', {
+
+      setup: function() {
+        this.sharedDecompositionViewDict = {};
+
+        // setup function
+        name = 'pcoa';
+        ids = ['PC.636', 'PC.635'];
+        coords = [
+          [-0.276542, -0.144964, 0.066647, -0.067711, 0.176070, 0.072969,
+          -0.229889, -0.046599],
+          [-0.237661, 0.046053, -0.138136, 0.159061, -0.247485, -0.115211,
+          -0.112864, 0.064794]];
+        pct_var = [26.6887048633, 16.2563704022, 13.7754129161, 11.217215823,
+        10.024774995, 8.22835130237, 7.55971173665, 6.24945796136];
+        md_headers = ['SampleID', 'LinkerPrimerSequence', 'Treatment', 'DOB'];
+        metadata = [['PC.636', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20070314'],
+        ['PC.635', 'YATGCTGCCTCCCGTAGGAGT', 'Fast', '20071112']];
+        decomp = new DecompositionModel(name, ids, coords, pct_var, md_headers,
+            metadata);
+        var dv = new DecompositionView(decomp);
+        this.sharedDecompositionViewDict.pcoa = dv;
+
+        name = 'biplot';
+        ids = ['tax_1', 'tax_2'];
+        coords = [
+          [-1, -0.144964, 0.066647, -0.067711, 0.176070, 0.072969,
+          -0.229889, -0.046599],
+          [-0.237661, 0.046053, -0.138136, 0.159061, -0.247485, -0.115211,
+          -0.112864, 0.064794]];
+        pct_var = [26.6887048633, 16.2563704022, 13.7754129161, 11.217215823,
+        10.024774995, 8.22835130237, 7.55971173665, 6.24945796136];
+        md_headers = ['SampleID', 'Gram'];
+        metadata = [['tax_1', '1'],
+        ['tax_2', '0']];
+        decomp = new DecompositionModel(name, ids, coords, pct_var, md_headers,
+            metadata);
+        dv = new DecompositionView(decomp);
+        this.sharedDecompositionViewDict.biplot = dv;
+        this.decomp = decomp;
+      },
+      teardown: function() {
+        this.sharedDecompositionViewDict = undefined;
+        this.decomp = undefined;
+      }
+    });
+
+    /**
+     *
+     * Test the constructor for EmperorViewController.
+     *
+     */
+    test('Constructor tests', function(assert) {
+      var container = $('<div id="does-not-exist"></div>');
+
+      // verify the subclassing was set properly
+      assert.ok(EmperorViewController.prototype instanceof
+                EmperorViewControllerABC);
+      var attr = new EmperorViewController(container, 'foo', 'bar',
+          this.sharedDecompositionViewDict);
+      equal(attr.activeViewKey, 'pcoa');
+    });
+
+    /**
+     *
+     * Tests to make sure the exceptions are being raised as expected
+     *
+     */
+    test('Cosnstructor test exceptions', function(assert) {
+      var dv = new DecompositionView(this.decomp);
+
+      throws(function() {
+        new EmperorViewController(container, 'foo', 'bar',
+            {1: 1, 2: 2}, {});
+
+      }, Error, 'The decomposition view dictionary ' +
+      'can only have decomposition views');
+
+      throws(function() {
+        new EmperorViewController(container, 'foo', 'bar',
+            {}, {});
+      }, Error, 'The decomposition view dictionary cannot be empty');
+    });
+
+    /**
+     *
+     * Test get active decomposition view key
+     *
+     */
+    test('Test getActiveDecompViewKey', function() {
+      var dv = new DecompositionView(this.decomp);
+      var container = $('<div id="does-not-exist"></div>');
+      var attr = new EmperorViewController(container, 'foo', 'bar',
+                                           {'scatter': dv});
+      equal(attr.getActiveDecompViewKey(), 'scatter');
+    });
+
+    /**
+     *
+     * Test set active decomposition view key
+     *
+     */
+    test('Test setActiveDecompViewKey', function() {
+      var dv = new DecompositionView(this.decomp);
+      var container = $('<div id="does-not-exist"></div>');
+      var attr = new EmperorViewController(container, 'foo', 'bar',
+          {'scatter': dv, 'biplot': dv});
+      equal(attr.getActiveDecompViewKey(), 'scatter');
+      attr.setActiveDecompViewKey('biplot');
+      equal(attr.getActiveDecompViewKey(), 'biplot');
+    });
 
     module('EmperorAttributeABC', {
 
@@ -212,7 +324,7 @@ requirejs([
 
       // verify the subclassing was set properly
       assert.ok(EmperorAttributeABC.prototype instanceof
-          EmperorViewControllerABC);
+                EmperorViewController);
       var attr = new EmperorAttributeABC(container, 'foo', 'bar',
           this.sharedDecompositionViewDict, {});
     });
@@ -238,27 +350,6 @@ requirejs([
 
         start(); // qunit
       });
-    });
-
-    /**
-     *
-     * Tests to make sure the exceptions are being raised as expected
-     *
-     */
-    test('Constructor test exceptions', function(assert) {
-      var dv = new DecompositionView(this.decomp);
-
-      throws(function() {
-        new EmperorAttributeABC(container, 'foo', 'bar',
-            {1: 1, 2: 2}, {});
-
-      }, Error, 'The decomposition view dictionary ' +
-      'can only have decomposition views');
-
-      throws(function() {
-        new EmperorAttributeABC(container, 'foo', 'bar',
-            {}, {});
-      }, Error, 'The decomposition view dictionary cannot be empty');
     });
 
     /**
@@ -297,35 +388,6 @@ requirejs([
           {'scatter': dv}, {});
       attr.setMetadataField('cheese');
       equal(attr.metadataField, 'cheese');
-    });
-
-    /**
-     *
-     * Test get active decomposition view key
-     *
-     */
-    test('Test getActiveDecompViewKey', function() {
-      var dv = new DecompositionView(this.decomp);
-      var container = $('<div id="does-not-exist"></div>');
-      var attr = new EmperorAttributeABC(container, 'foo', 'bar',
-          {'scatter': dv}, {});
-      equal(attr.getActiveDecompViewKey(), 'scatter');
-    });
-
-    /**
-     *
-     * Test set active decomposition view key
-     *
-     */
-    test('Test setActiveDecompViewKey', function() {
-      var dv = new DecompositionView(this.decomp);
-      var container = $('<div id="does-not-exist"></div>');
-      var attr = new EmperorAttributeABC(container, 'foo', 'bar',
-          {'scatter': dv, 'biplot': dv},
-          {});
-      equal(attr.getActiveDecompViewKey(), 'scatter');
-      attr.setActiveDecompViewKey('biplot');
-      equal(attr.getActiveDecompViewKey(), 'biplot');
     });
 
     /**


### PR DESCRIPTION
After starting the implementation of `AnimationsViewController`, I noticed that there would be a fair amount of repeated code between this new class, `AxesController` and `EmperorAttributeABC`, therefore I decided to move that redundant code to a new base class `EmperorViewController`.

This new class understands what a decomposition view dictionary is, but doesn't really alter the functionality that EmperorViewControllerABC provides. The tests and most of the code were extracted from `EmperorAttributeABC`.