### PR TITLE
Suggest adding url to make_emperor.py deprecation announcement

### DIFF
--- a/scripts/make_emperor.py
+++ b/scripts/make_emperor.py
@@ -8,5 +8,7 @@
 # ----------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    print("This script has been deprecated, please see the online "
-          "documentation at\n\thttp://emperor.microbio.me/uno/\n for more help.")
+    print("This script has been deprecated.")
+    print("For more help see the online documentation at")
+    print("\thttp://emperor.microbio.me/uno/")
+    


### PR DESCRIPTION
Please add the url http://emperor.microbio.me/uno/ to the deprecation printout in make_emperor.py.

If I know what I'm doing, this pull request contains the mod, which is simply inserting the url on a separate line
