### PR TITLE
HACK: Add extra attribute to denote text

### DIFF
--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -119,6 +119,10 @@ define(['underscore', 'three'], function(_, THREE) {
     var sp = new THREE.Sprite(mat);
     sp.position.set(position[0], position[1], position[2]);
 
+    // add an extra attribute so we can render this properly when we use
+    // SVGRenderer
+    sp.text = text;
+
     return sp;
   }
 

--- a/tests/javascript_tests/test_draw.js
+++ b/tests/javascript_tests/test_draw.js
@@ -70,6 +70,8 @@ requirejs(['draw'], function(draw) {
       equal(label.position.x, 0);
       equal(label.position.y, 0);
       equal(label.position.z, 0);
+
+      equal(label.text, 'foolibusters');
     });
 
     /**
@@ -87,6 +89,8 @@ requirejs(['draw'], function(draw) {
       equal(label.position.x, 0);
       equal(label.position.y, 0);
       equal(label.position.z, 0);
+
+      equal(label.text, 'foolibusters');
     });
 
     /**


### PR DESCRIPTION
THREE.Sprite objects can't properly be rendered when we use the
SVGRenderer, hence we add an extra attribute to the objects we return
from makeLabel. In this attribute text is stored, such that when
rendering we can check for its presence, and add the appropriate SVG
element.