### PR TITLE
PERF: Lazily load large studies to improve performance

### DIFF
--- a/emperor/support_files/js/abc-view-controller.js
+++ b/emperor/support_files/js/abc-view-controller.js
@@ -111,9 +111,9 @@ define([
   }
 
   /**
-   * Sets whether or not the tab can be modified or accessed.
+   * Sets whether or not elements in the tab can be modified.
    *
-   * @param {Boolean} trulse option to enable tab.
+   * @param {Boolean} trulse option to enable elements.
    */
   EmperorViewControllerABC.prototype.setEnabled = function(trulse) {
     if (typeof(trulse) === 'boolean') {

--- a/emperor/support_files/js/color-view-controller.js
+++ b/emperor/support_files/js/color-view-controller.js
@@ -208,6 +208,17 @@ define([
      return plottables;
    };
 
+  /**
+   * Sets whether or not elements in the tab can be modified.
+   *
+   * @param {Boolean} trulse option to enable elements.
+   */
+  ColorViewController.prototype.setEnabled = function(trulse){
+    EmperorAttributeABC.prototype.setEnabled.call(this, trulse);
+
+    this.$colormapSelect.prop('disabled', !trulse).trigger("chosen:updated");
+    this.$scaled.prop('disabled', !trulse);
+  }
 
   /**
    *

--- a/emperor/support_files/js/color-view-controller.js
+++ b/emperor/support_files/js/color-view-controller.js
@@ -213,12 +213,30 @@ define([
    *
    * @param {Boolean} trulse option to enable elements.
    */
-  ColorViewController.prototype.setEnabled = function(trulse){
+  ColorViewController.prototype.setEnabled = function(trulse) {
     EmperorAttributeABC.prototype.setEnabled.call(this, trulse);
 
-    this.$colormapSelect.prop('disabled', !trulse).trigger("chosen:updated");
+    this.$colormapSelect.prop('disabled', !trulse).trigger('chosen:updated');
     this.$scaled.prop('disabled', !trulse);
-  }
+  };
+
+  /**
+   *
+   * Private method to reset the color of all the objects in every
+   * decomposition view to red.
+   *
+   * @extends EmperorAttributeABC
+   * @private
+   *
+   */
+  ColorViewController.prototype._resetAttribute = function() {
+    EmperorAttributeABC.prototype._resetAttribute.call(this);
+
+    _.each(this.decompViewDict, function(view) {
+      view.setGroupColor(0xff0000, view.decomp.plottable);
+      view.needsUpdate = true;
+    });
+  };
 
   /**
    *
@@ -414,10 +432,19 @@ define([
    * @param {Object} Parsed JSON string representation of self.
    */
   ColorViewController.prototype.fromJSON = function(json) {
+    var data;
+
     // NOTE: We do not call super here because of the non-numeric values issue
     // Order here is important. We want to set all the extra controller
     // settings before we load from json, as they can override the JSON when set
-    var data;
+    this.setMetadataField(json.category);
+
+    // if the category is null, then there's nothing to set about the state
+    // of the controller
+    if (json.category === null) {
+      return;
+    }
+
     this.$select.val(json.category);
     this.$select.trigger('chosen:updated');
     this.$colormapSelect.val(json.colormap);
@@ -431,14 +458,14 @@ define([
     var decompViewDict = this.getView();
     if (this.$scaled.is(':checked')) {
       // Get the current SlickGrid data and update with the saved color
-      var data = this.bodyGrid.getData();
+      data = this.bodyGrid.getData();
       data[0].value = json.data['Non-numeric values'];
       this.setPlottableAttributes(
         decompViewDict, json.data['Non-numeric values'], data[0].plottables);
 
     }
     else {
-      var data = decompViewDict.setCategory(
+      data = decompViewDict.setCategory(
         json.data, this.setPlottableAttributes, json.category);
     }
     this.setSlickGridDataset(data);

--- a/emperor/support_files/js/color-view-controller.js
+++ b/emperor/support_files/js/color-view-controller.js
@@ -51,16 +51,19 @@ define([
     this.$colorScale = $("<svg width='90%' height='100%' " +
                          "'style='display:block;margin:auto;'></svg>");
     this.$scaleDiv.append(this.$colorScale);
+    this.$scaleDiv.hide();
     /**
      * @type {Node}
      *  jQuery object holding the continuous value checkbox
      */
     this.$scaled = $("<input type='checkbox'>");
+    this.$scaled.prop('hidden', true);
     /**
      * @type {Node}
      *  jQuery object holding the continuous value label
      */
     this.$scaledLabel = $("<label for='scaled'>Continuous values</label>");
+    this.$scaledLabel.prop('hidden', true);
 
     // this class uses a colormap selector, so populate it before calling super
     // because otherwise the categorySelectionCallback will be called before the

--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -608,7 +608,7 @@ define([
     sceneview.control.update();
 
     //load the rest of the controller settings
-     _.each(this.controllers, function(controller, index) {
+    _.each(this.controllers, function(controller, index) {
       if (controller !== undefined) {
         controller.fromJSON(json[index]);
       }

--- a/emperor/support_files/js/scale-view-controller.js
+++ b/emperor/support_files/js/scale-view-controller.js
@@ -207,6 +207,18 @@ define([
   };
 
   /**
+   * Sets whether or not elements in the tab can be modified.
+   *
+   * @param {Boolean} trulse option to enable elements.
+   */
+  ScaleViewController.prototype.setEnabled = function(trulse){
+    EmperorAttributeABC.prototype.setEnabled.call(this, trulse);
+
+    this.$scaledValue.prop('disabled', !trulse);
+    this.$sliderGlobal.slider('option', 'disabled', !trulse);
+  }
+
+  /**
    * Helper function to set the scale of plottable
    *
    * @param {Object} scope The scope where the plottables exist

--- a/emperor/support_files/js/scale-view-controller.js
+++ b/emperor/support_files/js/scale-view-controller.js
@@ -146,6 +146,24 @@ define([
   ScaleViewController.prototype.constructor = EmperorAttributeABC;
 
   /**
+   *
+   * Private method to reset the scale of all the objects to one.
+   *
+   * @extends EmperorAttributeABC
+   * @private
+   *
+   */
+  ScaleViewController.prototype._resetAttribute = function() {
+    EmperorAttributeABC.prototype._resetAttribute.call(this);
+
+    _.each(this.decompViewDict, function(view) {
+      this.setPlottableAttributes(view, 1, view.decomp.plottable);
+      view.needsUpdate = true;
+      this.$scaledValue.prop('checked', false);
+    });
+  };
+
+  /**
    * Converts the current instance into a JSON string.
    *
    * @return {Object} JSON ready representation of self.
@@ -166,6 +184,15 @@ define([
     // Can't call super because select needs to be set first
     // Order here is important. We want to set all the extra controller
     // settings before we load from json, as they can override the JSON when set
+
+    this.setMetadataField(json.category);
+
+    // if the category is null, then there's nothing to set about the state
+    // of the controller
+    if (json.category === null) {
+      return;
+    }
+
     this.$select.val(json.category);
     this.$select.trigger('chosen:updated');
     this.$sliderGlobal.slider('value', json.globalScale);
@@ -211,12 +238,12 @@ define([
    *
    * @param {Boolean} trulse option to enable elements.
    */
-  ScaleViewController.prototype.setEnabled = function(trulse){
+  ScaleViewController.prototype.setEnabled = function(trulse) {
     EmperorAttributeABC.prototype.setEnabled.call(this, trulse);
 
     this.$scaledValue.prop('disabled', !trulse);
     this.$sliderGlobal.slider('option', 'disabled', !trulse);
-  }
+  };
 
   /**
    * Helper function to set the scale of plottable

--- a/emperor/support_files/js/scale-view-controller.js
+++ b/emperor/support_files/js/scale-view-controller.js
@@ -155,12 +155,13 @@ define([
    */
   ScaleViewController.prototype._resetAttribute = function() {
     EmperorAttributeABC.prototype._resetAttribute.call(this);
+    var scope = this;
 
     _.each(this.decompViewDict, function(view) {
-      this.setPlottableAttributes(view, 1, view.decomp.plottable);
+      scope.setPlottableAttributes(view, 1, view.decomp.plottable);
       view.needsUpdate = true;
-      this.$scaledValue.prop('checked', false);
     });
+    this.$scaledValue.prop('checked', false);
   };
 
   /**

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -552,19 +552,14 @@ define([
       updateColors = true;
     }
 
-    // if autorotation is enabled, then update the controls to trigger an
-    // update, it's an equivalent to asking for re-rendering
-    if (this.control.autoRotate) {
-      this.control.update();
-    }
-
     if (updateData) {
       this.drawAxesWithColor(this.axesColor);
       this.drawAxesLabelsWithColor(this.axesColor);
     }
 
     // if anything has changed, then trigger an update
-    return this.needsUpdate || updateData || updateDimensions || updateColors;
+    return (this.needsUpdate || updateData || updateDimensions ||
+            updateColors || this.control.autoRotate);
    };
 
   /**
@@ -576,10 +571,15 @@ define([
     this.renderer.setViewport(this.xView, this.yView, this.width, this.height);
     this.renderer.render(this.scene, this.camera);
     var camera = this.camera;
+
+    // if autorotation is enabled, then update the controls
+    this.control.update();
+
     //point all samples towards the camera
     _.each(this.decViews.scatter.markers, function(element) {
       element.quaternion.copy(camera.quaternion);
     });
+
     this.needsUpdate = false;
     $.each(this.decViews, function(key, val) {
       val.needsUpdate = false;

--- a/emperor/support_files/js/shape-controller.js
+++ b/emperor/support_files/js/shape-controller.js
@@ -79,6 +79,23 @@ define([
   ShapeController.prototype.constructor = EmperorAttributeABC;
 
   /**
+   *
+   * Private method to reset the shape of all the objects to spheres.
+   *
+   * @extends EmperorAttributeABC
+   * @private
+   *
+   */
+  ShapeController.prototype._resetAttribute = function() {
+    EmperorAttributeABC.prototype._resetAttribute.call(this);
+
+    _.each(this.decompViewDict, function(view) {
+      this.setPlottableAttributes(view, 'Sphere', view.decomp.plottable);
+      view.needsUpdate = true;
+    });
+  };
+
+  /**
    * Helper function to set the shape of plottable
    *
    * @param {Object} scope The scope where the plottables exist

--- a/emperor/support_files/js/shape-controller.js
+++ b/emperor/support_files/js/shape-controller.js
@@ -88,9 +88,10 @@ define([
    */
   ShapeController.prototype._resetAttribute = function() {
     EmperorAttributeABC.prototype._resetAttribute.call(this);
+    var scope = this;
 
     _.each(this.decompViewDict, function(view) {
-      this.setPlottableAttributes(view, 'Sphere', view.decomp.plottable);
+      scope.setPlottableAttributes(view, 'Sphere', view.decomp.plottable);
       view.needsUpdate = true;
     });
   };

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -155,12 +155,15 @@ define([
 
       // only subclasses will provide this callback
       if (options.categorySelectionCallback !== undefined) {
+
         scope.$select.chosen().change(options.categorySelectionCallback);
 
-        // now that we have the chosen selector and the table fire a callback
-        // to initialize the data grid
-        options.categorySelectionCallback(
-          null, {selected: scope.$select.val()});
+        // If the number of samples is not too large, fire a callback using the
+        // selector to initialize the data grid
+        if (dm.ids.length < 1000) {
+          options.categorySelectionCallback(
+            null, {selected: scope.$select.val()});
+        }
       }
 
     });

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -215,14 +215,41 @@ define([
   };
 
   /**
+   *
+   * Private method to reset the attributes of the controller.
+   *
+   * Subclasses should implement this method as a way to reset the visual
+   * attributes of a given plot.
+   * @private
+   *
+   */
+  EmperorAttributeABC.prototype._setDefault = function() {
+  };
+
+  /**
    * Changes the selected value in the metadata menu.
    *
-   * @param {String} m Metadata column name to control.
+   * @param {String} m Metadata column name to control. When the category is
+   * ``null``, the metadata selector is set to an empty value, the body grid
+   * is emptied, and all the markers are reset to a default state (depends on
+   * the subclass).
    *
    * @throws {Error} Argument `m` must be a metadata category in one of the
    * decomposition views.
    */
   EmperorAttributeABC.prototype.setMetadataField = function(m) {
+    if (m === null) {
+      this._resetAttribute();
+
+      this.$select.val('');
+      this.bodyGrid.setData([]);
+
+      this.setEnabled(false);
+      this.$select.prop('disabled', false).trigger('chosen:updated');
+
+      return;
+    }
+
     // loop through the metadata headers in the decompositon views
     // FIXME: There's no good way to specify the current decomposition name
     // this needs to be added to the interface.
@@ -364,12 +391,15 @@ define([
   EmperorAttributeABC.prototype.fromJSON = function(json) {
     this.setMetadataField(json.category);
 
-    // fetch and set the SlickGrid-formatted data
-    var data = this.getView().setCategory(
-      json.data, this.setPlottableAttributes, json.category);
-    this.setSlickGridDataset(data);
-    // set all to needsUpdate
-    this.getView().needsUpdate = true;
+    // if the category is null, then we just reset the controller
+    if (json.category !== null) {
+      // fetch and set the SlickGrid-formatted data
+      var data = this.getView().setCategory(
+        json.data, this.setPlottableAttributes, json.category);
+      this.setSlickGridDataset(data);
+      // set all to needsUpdate
+      this.getView().needsUpdate = true;
+    }
   };
 
   /**
@@ -389,7 +419,7 @@ define([
 
     _.each(this.decompViewDict, function(view, name) {
       // sort alphabetically the metadata headers (
-      hdrs = _.sortBy(view.decomp.md_headers, function(x){
+      hdrs = _.sortBy(view.decomp.md_headers, function(x) {
         return x.toLowerCase();
       });
 
@@ -427,7 +457,7 @@ define([
   EmperorAttributeABC.prototype.setEnabled = function(trulse) {
     EmperorViewController.prototype.setEnabled.call(this, trulse);
 
-    this.$select.prop('disabled', !trulse).trigger("chosen:updated");
+    this.$select.prop('disabled', !trulse).trigger('chosen:updated');
     this.bodyGrid.setOptions({editable: trulse});
   };
 

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -365,7 +365,9 @@ define([
 
     _.each(this.decompViewDict, function(view, name) {
       // retrieve the metadata headers for this decomposition
-      hdrs = view.decomp.md_headers;
+      hdrs = _.sortBy(view.decomp.md_headers, function(x){
+        return x.toLowerCase();
+      });
 
       // Before we update the metadata view, we rectify that we don't have that
       // information already. The order in this conditional matters as we hope

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -223,7 +223,7 @@ define([
    * @private
    *
    */
-  EmperorAttributeABC.prototype._setDefault = function() {
+  EmperorAttributeABC.prototype._resetAttribute = function() {
   };
 
   /**

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -242,7 +242,7 @@ define([
       this._resetAttribute();
 
       this.$select.val('');
-      this.bodyGrid.setData([]);
+      this.setSlickGridDataset([]);
 
       this.setEnabled(false);
       this.$select.prop('disabled', false).trigger('chosen:updated');

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -159,24 +159,15 @@ define([
       // only subclasses will provide this callback
       if (options.categorySelectionCallback !== undefined) {
 
-        // If the number of samples is not too large, fire a callback using the
-        // selector to initialize the data grid
-        if (dm.ids.length < 1000) {
-          options.categorySelectionCallback(
-            null, {selected: scope.$select.val()});
-        }
-        else {
-          // Disable interface controls (except the metadata selector) to
-          // prevent errors while no metadata category is selected. Once the
-          // user selects a metadata category, the controls will be enabled
-          // (see setSlickGridDataset).
-          scope.setEnabled(false);
-          scope.$select.val('');
-          scope.$select.prop('disabled', false).trigger('chosen:updated');
-        }
+        // Disable interface controls (except the metadata selector) to
+        // prevent errors while no metadata category is selected. Once the
+        // user selects a metadata category, the controls will be enabled
+        // (see setSlickGridDataset).
+        scope.setEnabled(false);
+        scope.$select.val('');
+        scope.$select.prop('disabled', false).trigger('chosen:updated');
 
         scope.$select.chosen().change(options.categorySelectionCallback);
-
       }
 
     });
@@ -292,8 +283,8 @@ define([
    */
   EmperorAttributeABC.prototype.setSlickGridDataset = function(data) {
 
-    // Accounts for cases where controllers are not auto-initialized to a
-    // metadata category. In these cases all controllers (except the metadata
+    // Accounts for cases where controllers have not been set to a metadata
+    // category. In these cases all controllers (except for the metadata
     // selector) are disabled to prevent interface errors.
     if (this.getSlickGridDataset().length === 0 && this.enabled === false) {
       this.setEnabled(true);

--- a/emperor/support_files/js/visibility-controller.js
+++ b/emperor/support_files/js/visibility-controller.js
@@ -74,6 +74,23 @@ define([
   VisibilityController.prototype.constructor = EmperorAttributeABC;
 
   /**
+   *
+   * Private method to reset all objects to be visible.
+   *
+   * @extends EmperorAttributeABC
+   * @private
+   *
+   */
+  VisibilityController.prototype._resetAttribute = function() {
+    EmperorAttributeABC.prototype._resetAttribute.call(this);
+
+    _.each(this.decompViewDict, function(view) {
+      this.setPlottableAttributes(view, true, view.decomp.plottable);
+      view.needsUpdate = true;
+    });
+  };
+
+  /**
    * Helper function to set the visibility of plottable
    *
    * @param {Object} scope the scope where the plottables exist

--- a/emperor/support_files/js/visibility-controller.js
+++ b/emperor/support_files/js/visibility-controller.js
@@ -83,9 +83,10 @@ define([
    */
   VisibilityController.prototype._resetAttribute = function() {
     EmperorAttributeABC.prototype._resetAttribute.call(this);
+    var scope = this;
 
     _.each(this.decompViewDict, function(view) {
-      this.setPlottableAttributes(view, true, view.decomp.plottable);
+      scope.setPlottableAttributes(view, true, view.decomp.plottable);
       view.needsUpdate = true;
     });
   };

--- a/tests/javascript_tests/index.html
+++ b/tests/javascript_tests/index.html
@@ -177,7 +177,7 @@
            'test_color_view_controller', 'test_sceneplotview3d',
            'test_trajectory', 'test_animate', 'test_util',  'test_draw',
            'test_visibility_controller', 'test_shape_controller',
-           'test_axes_controller'],
+           'test_scale_view_controller', 'test_axes_controller'],
            /*
               Very important to always load all dependencies first, otherwise
               you might encounter problems with Qunit not running all tests.

--- a/tests/javascript_tests/test_color_view_controller.js
+++ b/tests/javascript_tests/test_color_view_controller.js
@@ -542,6 +542,40 @@ requirejs([
       equal(controller.$scaled.is(':checked'), true);
     });
 
+    test('Testing toJSON (null)', function() {
+      var container = $('<div style="height:11px; width:12px"></div>');
+      var controller = new ColorViewController(
+        container, this.sharedDecompositionViewDict);
+      controller.setMetadataField(null);
+
+      var obs = controller.toJSON();
+      var exp = {'category': null,
+                 'colormap': 'discrete-coloring-qiime',
+                 'continuous': false,
+                 'data': {}};
+      deepEqual(obs, exp);
+    });
+
+    test('Testing fromJSON (null)', function() {
+      var json = {category: null,
+                  colormap: 'discrete-coloring-qiime',
+                  continuous: false,
+                  data: {}};
+
+      var container = $('<div style="height:11px; width:12px"></div>');
+      var controller = new ColorViewController(
+        container, this.sharedDecompositionViewDict);
+
+      controller.fromJSON(json);
+      var markers = controller.decompViewDict.scatter.markers;
+      equal(markers[0].material.color.getHexString(), 'ff0000');
+      equal(markers[1].material.color.getHexString(), 'ff0000');
+      equal(markers[2].material.color.getHexString(), 'ff0000');
+      equal(controller.$select.val(), null);
+      equal(controller.$colormapSelect.val(), 'discrete-coloring-qiime');
+      equal(controller.$scaled.is(':checked'), false);
+    });
+
     asyncTest('Test setEnabled', function() {
       var container = $('<div style="height:11px; width:12px"></div>');
       var controller = new ColorViewController(
@@ -553,6 +587,39 @@ requirejs([
 
         equal(controller.$colormapSelect.is(':disabled'), true);
         equal(controller.$scaled.is(':disabled'), true);
+
+        start(); // qunit
+      });
+    });
+
+    /**
+     *
+     * Test large dataset.
+     *
+     */
+    asyncTest('Test large dataset', function() {
+      var coords = [], metadata = [];
+      for (var i = 0; i < 1001; i++) {
+        coords.push([Math.random(), Math.random(), Math.random(),
+                     Math.random()]);
+        metadata.push([i, 'b ' + Math.random(), 'c ' + Math.random()]);
+      }
+
+      var d = new DecompositionModel('pcoa', _.range(1001), coords,
+                                     [45, 35, 15, 5],
+                                     ['SampleID', 'foo', 'bar'], metadata);
+      var dv = new DecompositionView(d);
+      var container = $('<div id="does-not-exist"></div>');
+      // create a dummy category selection callback
+      var options = {'categorySelectionCallback': function() {}};
+      var attr = new ColorViewController(container, {'scatter': dv});
+      $(function() {
+        // Controllers should be enabled
+        equal(attr.enabled, false);
+        equal(attr.$select.val(), null);
+        equal(attr.$select.is(':disabled'), false);
+        equal(attr.$colormapSelect.is(':disabled'), true);
+        equal(attr.$scaled.is(':disabled'), true);
 
         start(); // qunit
       });

--- a/tests/javascript_tests/test_color_view_controller.js
+++ b/tests/javascript_tests/test_color_view_controller.js
@@ -97,7 +97,7 @@ requirejs([
 
       // verify the color value is set properly
       equal(controller.$colormapSelect.val(), 'discrete-coloring-qiime');
-      equal(controller.$select.val(), 'SampleID');
+      equal(controller.$select.val(), 'DOB');
     });
 
     test('Test _nonNumericPlottables', function() {
@@ -492,11 +492,10 @@ requirejs([
                                                            plottables);
 
       var obs = controller.toJSON();
-      var exp = {category: 'SampleID',
-                 colormap: 'discrete-coloring-qiime',
-                 continuous: false,
-                 data: {'PC.636': '#ff0000', 'PC.635': '#0000ff',
-                        'PC.634': '#f27304'}};
+      var exp = {'category': 'DOB',
+                 'colormap': 'discrete-coloring-qiime',
+                 'continuous': false,
+                 'data': { '20070314': '#ff0000', '20071112': '#0000ff'}};
       deepEqual(obs, exp);
     });
 

--- a/tests/javascript_tests/test_color_view_controller.js
+++ b/tests/javascript_tests/test_color_view_controller.js
@@ -97,10 +97,10 @@ requirejs([
 
       // verify the color value is set properly
       equal(controller.$colormapSelect.val(), 'discrete-coloring-qiime');
-      equal(controller.$select.val(), 'DOB');
+      equal(controller.$select.val(), null);
 
-      equal(controller.$colormapSelect.is(':disabled'), false);
-      equal(controller.$scaled.is(':disabled'), false);
+      equal(controller.$colormapSelect.is(':disabled'), true);
+      equal(controller.$scaled.is(':disabled'), true);
     });
 
     test('Test _nonNumericPlottables', function() {
@@ -108,6 +108,7 @@ requirejs([
                         'width:12px"></div>');
       var controller = new ColorViewController(
         container, this.sharedDecompositionViewDict);
+      controller.setMetadataField('DOB');
       var decompViewDict = controller.getView();
 
       var colors = {'14.7': '#f7fbff',
@@ -494,6 +495,7 @@ requirejs([
       ColorViewController.prototype.setPlottableAttributes(this.dv, '#00ff00',
                                                            plottables);
 
+      controller.setMetadataField('DOB');
       var obs = controller.toJSON();
       var exp = {'category': 'DOB',
                  'colormap': 'discrete-coloring-qiime',

--- a/tests/javascript_tests/test_color_view_controller.js
+++ b/tests/javascript_tests/test_color_view_controller.js
@@ -557,5 +557,39 @@ requirejs([
         start(); // qunit
       });
     });
+
+    /**
+     *
+     * Test large dataset.
+     *
+     */
+    asyncTest('Test large dataset', function() {
+      var coords = [], metadata = [];
+      for (var i = 0; i < 1001; i++){
+        coords.push([Math.random(), Math.random(), Math.random(),
+                     Math.random()]);
+        metadata.push([i, 'b ' + Math.random(), 'c ' + Math.random()]);
+      }
+
+      var d = new DecompositionModel('pcoa', _.range(1001), coords,
+                                     [45, 35, 15, 5],
+                                     ['SampleID', 'foo', 'bar'], metadata);
+      var dv = new DecompositionView(d);
+      var container = $('<div id="does-not-exist"></div>');
+      // create a dummy category selection callback
+      var options = {'categorySelectionCallback': function(){}};
+      var attr = new ColorViewController(container, {'scatter': dv});
+      $(function() {
+        // Controllers should be enabled
+        equal(attr.enabled, false);
+        equal(attr.$select.val(), null);
+        equal(attr.$select.is(':disabled'), false);
+        equal(attr.$colormapSelect.is(':disabled'), true);
+        equal(attr.$scaled.is(':disabled'), true);
+
+        start(); // qunit
+      });
+    });
+
   });
 });

--- a/tests/javascript_tests/test_color_view_controller.js
+++ b/tests/javascript_tests/test_color_view_controller.js
@@ -565,7 +565,7 @@ requirejs([
      */
     asyncTest('Test large dataset', function() {
       var coords = [], metadata = [];
-      for (var i = 0; i < 1001; i++){
+      for (var i = 0; i < 1001; i++) {
         coords.push([Math.random(), Math.random(), Math.random(),
                      Math.random()]);
         metadata.push([i, 'b ' + Math.random(), 'c ' + Math.random()]);
@@ -577,7 +577,7 @@ requirejs([
       var dv = new DecompositionView(d);
       var container = $('<div id="does-not-exist"></div>');
       // create a dummy category selection callback
-      var options = {'categorySelectionCallback': function(){}};
+      var options = {'categorySelectionCallback': function() {}};
       var attr = new ColorViewController(container, {'scatter': dv});
       $(function() {
         // Controllers should be enabled

--- a/tests/javascript_tests/test_color_view_controller.js
+++ b/tests/javascript_tests/test_color_view_controller.js
@@ -98,6 +98,9 @@ requirejs([
       // verify the color value is set properly
       equal(controller.$colormapSelect.val(), 'discrete-coloring-qiime');
       equal(controller.$select.val(), 'DOB');
+
+      equal(controller.$colormapSelect.is(':disabled'), false);
+      equal(controller.$scaled.is(':disabled'), false);
     });
 
     test('Test _nonNumericPlottables', function() {
@@ -537,6 +540,22 @@ requirejs([
       equal(controller.$select.val(), 'Mixed');
       equal(controller.$colormapSelect.val(), 'Viridis');
       equal(controller.$scaled.is(':checked'), true);
+    });
+
+    asyncTest('Test setEnabled', function() {
+      var container = $('<div style="height:11px; width:12px"></div>');
+      var controller = new ColorViewController(
+        container, this.sharedDecompositionViewDict);
+
+      $(function() {
+        // disable
+        controller.setEnabled(false);
+
+        equal(controller.$colormapSelect.is(':disabled'), true);
+        equal(controller.$scaled.is(':disabled'), true);
+
+        start(); // qunit
+      });
     });
   });
 });

--- a/tests/javascript_tests/test_scale_view_controller.js
+++ b/tests/javascript_tests/test_scale_view_controller.js
@@ -98,7 +98,10 @@ requirejs([
 
       // verify the checked value is set properly
       equal(controller.$scaledValue.is(':checked'), false);
-      equal(controller.$select.val(), 'SampleID');
+      equal(controller.$select.val(), 'DOB');
+
+      equal(controller.$scaledValue.is(':disabled'), false);
+      equal(controller.$sliderGlobal.is(':disabled'), false);
     });
 
     test('Testing setPlottableAttributes helper function', function(assert) {
@@ -141,8 +144,8 @@ requirejs([
         container, this.sharedDecompositionViewDict);
 
       var obs = controller.toJSON();
-      var exp = {category: 'SampleID', globalScale: '1.0', scaleVal: false,
-                 data: {'PC.636': 1, 'PC.635': 1, 'PC.634': 1}};
+      var exp = {category: 'DOB', globalScale: '1.0', scaleVal: false,
+                 data: {'20070314': 1, '20071112': 1}};
       deepEqual(obs, exp);
     });
 
@@ -209,5 +212,21 @@ requirejs([
       var exp = {'1': 1, 'no': 0, 'false': 0, 'something': 0, '2': 5};
       deepEqual(obs, exp);
     });
+
+    asyncTest('Test setEnabled (true)', function() {
+      var container = $('<div id="does-not-exist" style="height:11px; ' +
+                        'width:12px"></div>');
+      var controller = new ScaleViewController(
+        container, this.sharedDecompositionViewDict);
+      $(function() {
+        controller.setEnabled(false);
+
+        equal(controller.$scaledValue.is(':disabled'), true);
+        equal(controller.$sliderGlobal.slider('option', 'disabled'), true);
+
+        start(); // qunit
+      });
+    });
+
   });
 });

--- a/tests/javascript_tests/test_scale_view_controller.js
+++ b/tests/javascript_tests/test_scale_view_controller.js
@@ -195,6 +195,44 @@ requirejs([
       equal(controller.$scaledValue.is(':checked'), true);
     });
 
+    test('Testing toJSON (null)', function() {
+      var container = $('<div id="does-not-exist" style="height:11px; ' +
+                        'width:12px"></div>');
+      var controller = new ScaleViewController(
+        container, this.sharedDecompositionViewDict);
+      controller.setMetadataField(null);
+
+      var obs = controller.toJSON();
+      var exp = {category: null, globalScale: '1.0', scaleVal: false,
+                 data: {}};
+      deepEqual(obs, exp);
+    });
+
+    test('Testing fromJSON (null)', function() {
+      var json = {category: null, globalScale: '1.0', scaleVal: false,
+                  data: {}};
+
+      var container = $('<div id="does-not-exist" style="height:11px; ' +
+                        'width:12px"></div>');
+      var controller = new ScaleViewController(
+        container, this.sharedDecompositionViewDict);
+
+      controller.fromJSON(json);
+      var idx = 0;
+      var scatter = controller.decompViewDict.scatter;
+      deepEqual(scatter.markers[0].scale.x, 1);
+      deepEqual(scatter.markers[0].scale.y, 1);
+      deepEqual(scatter.markers[0].scale.z, 1);
+      deepEqual(scatter.markers[1].scale.x, 1);
+      deepEqual(scatter.markers[1].scale.y, 1);
+      deepEqual(scatter.markers[1].scale.z, 1);
+      deepEqual(scatter.markers[2].scale.x, 1);
+      deepEqual(scatter.markers[2].scale.y, 1);
+      deepEqual(scatter.markers[2].scale.z, 1);
+      equal(controller.getMetadataField(), null);
+      equal(controller.$scaledValue.is(':checked'), false);
+    });
+
     test('Testing getScale', function() {
       var container = $('<div id="does-not-exist" style="height:11px; ' +
                         'width:12px"></div>');

--- a/tests/javascript_tests/test_scale_view_controller.js
+++ b/tests/javascript_tests/test_scale_view_controller.js
@@ -235,7 +235,7 @@ requirejs([
      */
     asyncTest('Test large dataset', function() {
       var coords = [], metadata = [];
-      for (var i = 0; i < 1001; i++){
+      for (var i = 0; i < 1001; i++) {
         coords.push([Math.random(), Math.random(), Math.random(),
                      Math.random()]);
         metadata.push([i, 'b ' + Math.random(), 'c ' + Math.random()]);
@@ -247,7 +247,7 @@ requirejs([
       var dv = new DecompositionView(d);
       var container = $('<div id="does-not-exist"></div>');
       // create a dummy category selection callback
-      var options = {'categorySelectionCallback': function(){}};
+      var options = {'categorySelectionCallback': function() {}};
       var attr = new ScaleViewController(container, {'scatter': dv});
       $(function() {
         // Controllers should be enabled

--- a/tests/javascript_tests/test_scale_view_controller.js
+++ b/tests/javascript_tests/test_scale_view_controller.js
@@ -98,9 +98,9 @@ requirejs([
 
       // verify the checked value is set properly
       equal(controller.$scaledValue.is(':checked'), false);
-      equal(controller.$select.val(), 'DOB');
+      equal(controller.$select.val(), null);
 
-      equal(controller.$scaledValue.is(':disabled'), false);
+      equal(controller.$scaledValue.is(':disabled'), true);
       equal(controller.$sliderGlobal.is(':disabled'), false);
     });
 
@@ -143,6 +143,7 @@ requirejs([
       var controller = new ScaleViewController(
         container, this.sharedDecompositionViewDict);
 
+      controller.setMetadataField('DOB');
       var obs = controller.toJSON();
       var exp = {category: 'DOB', globalScale: '1.0', scaleVal: false,
                  data: {'20070314': 1, '20071112': 1}};

--- a/tests/javascript_tests/test_scale_view_controller.js
+++ b/tests/javascript_tests/test_scale_view_controller.js
@@ -228,5 +228,39 @@ requirejs([
       });
     });
 
+    /**
+     *
+     * Test large dataset.
+     *
+     */
+    asyncTest('Test large dataset', function() {
+      var coords = [], metadata = [];
+      for (var i = 0; i < 1001; i++){
+        coords.push([Math.random(), Math.random(), Math.random(),
+                     Math.random()]);
+        metadata.push([i, 'b ' + Math.random(), 'c ' + Math.random()]);
+      }
+
+      var d = new DecompositionModel('pcoa', _.range(1001), coords,
+                                     [45, 35, 15, 5],
+                                     ['SampleID', 'foo', 'bar'], metadata);
+      var dv = new DecompositionView(d);
+      var container = $('<div id="does-not-exist"></div>');
+      // create a dummy category selection callback
+      var options = {'categorySelectionCallback': function(){}};
+      var attr = new ScaleViewController(container, {'scatter': dv});
+      $(function() {
+        // Controllers should be enabled
+        equal(attr.enabled, false);
+        equal(attr.$select.val(), null);
+        equal(attr.$select.is(':disabled'), false);
+
+        equal(attr.$scaledValue.is(':disabled'), true);
+        equal(attr.$sliderGlobal.slider('option', 'disabled'), true);
+
+        start(); // qunit
+      });
+    });
+
   });
 });

--- a/tests/javascript_tests/test_shape_controller.js
+++ b/tests/javascript_tests/test_shape_controller.js
@@ -160,6 +160,7 @@ requirejs([
       var controller = new ShapeController(container,
                                            this.sharedDecompositionViewDict);
 
+      controller.setMetadataField('DOB');
       var obs = controller.toJSON();
       var exp = {category: 'DOB',
                  data: {'20070314': 'Sphere', '20071112': 'Sphere'}

--- a/tests/javascript_tests/test_shape_controller.js
+++ b/tests/javascript_tests/test_shape_controller.js
@@ -185,5 +185,35 @@ requirejs([
             'SphereGeometry');
     });
 
+    test('Testing toJSON (null)', function() {
+      var container = $('<div id="does-not-exist" style="height:11px; ' +
+                        'width:12px"></div>');
+      var controller = new ShapeController(container,
+                                           this.sharedDecompositionViewDict);
+
+      controller.setMetadataField(null);
+      var obs = controller.toJSON();
+      var exp = {category: null,
+                 data: {}
+      };
+      deepEqual(obs, exp);
+    });
+
+    test('Testing fromJSON (null)', function() {
+      var json = {'category': null, 'data': {}};
+
+      var container = $('<div id="does-not-exist" style="height:11px; ' +
+                        'width:12px"></div>');
+      var controller = new ShapeController(container,
+                                           this.sharedDecompositionViewDict);
+
+      controller.fromJSON(json);
+      var idx = 0;
+      equal(controller.decompViewDict.scatter.markers[idx].geometry.type,
+            'SphereGeometry');
+      equal(controller.decompViewDict.scatter.markers[idx + 1].geometry.type,
+            'SphereGeometry');
+    });
+
   });
 });

--- a/tests/javascript_tests/test_shape_controller.js
+++ b/tests/javascript_tests/test_shape_controller.js
@@ -161,8 +161,8 @@ requirejs([
                                            this.sharedDecompositionViewDict);
 
       var obs = controller.toJSON();
-      var exp = {category: 'SampleID',
-                 data: {'PC.636': 'Sphere', 'PC.635': 'Sphere'}
+      var exp = {category: 'DOB',
+                 data: {'20070314': 'Sphere', '20071112': 'Sphere'}
       };
       deepEqual(obs, exp);
     });

--- a/tests/javascript_tests/test_view_controller.js
+++ b/tests/javascript_tests/test_view_controller.js
@@ -486,7 +486,7 @@ requirejs([
      * Test setEnabled (false)
      *
      */
-    asyncTest('Test setEnabled false', function() {
+    asyncTest('Test setEnabled (false)', function() {
       var dv = new DecompositionView(this.decomp);
       var container = $('<div id="does-not-exist"></div>');
       var attr = new EmperorAttributeABC(container, 'foo', 'bar',
@@ -515,7 +515,7 @@ requirejs([
      * Test setEnabled (true)
      *
      */
-    asyncTest('Test setEnabled true', function() {
+    asyncTest('Test setEnabled (true)', function() {
       var dv = new DecompositionView(this.decomp);
       var container = $('<div id="does-not-exist"></div>');
       var attr = new EmperorAttributeABC(container, 'foo', 'bar',
@@ -535,7 +535,6 @@ requirejs([
         start(); // qunit
       });
     });
-
 
   });
 });

--- a/tests/javascript_tests/test_view_controller.js
+++ b/tests/javascript_tests/test_view_controller.js
@@ -536,5 +536,37 @@ requirejs([
       });
     });
 
+    /**
+     *
+     * Test large dataset.
+     *
+     */
+    asyncTest('Test large dataset', function() {
+      var coords = [], metadata = [];
+      for (var i = 0; i < 1001; i++){
+        coords.push([Math.random(), Math.random(), Math.random(),
+                     Math.random()]);
+        metadata.push([i, 'b ' + Math.random(), 'c ' + Math.random()]);
+      }
+
+      var d = new DecompositionModel('pcoa', _.range(1001), coords,
+                                     [45, 35, 15, 5],
+                                     ['SampleID', 'foo', 'bar'], metadata);
+      var dv = new DecompositionView(d);
+      var container = $('<div id="does-not-exist"></div>');
+      // create a dummy category selection callback
+      var options = {'categorySelectionCallback': function(){}};
+      var attr = new EmperorAttributeABC(container, 'foo', 'bar',
+                                         {'scatter': dv}, options);
+      $(function() {
+        // Controllers should be enabled
+        equal(attr.enabled, false);
+        equal(attr.$select.val(), null);
+        equal(attr.$select.is(':disabled'), false);
+
+        start(); // qunit
+      });
+    });
+
   });
 });

--- a/tests/javascript_tests/test_view_controller.js
+++ b/tests/javascript_tests/test_view_controller.js
@@ -6,7 +6,7 @@ requirejs([
     'abcviewcontroller',
     'viewcontroller',
     'slickgrid'
-], function($, _, model, DecompositionView, abcviewcontroller, viewcontroller,
+], function($, _, model, DecompositionView, abc, viewcontroller,
             SlickGrid) {
   var EmperorViewControllerABC = abc.EmperorViewControllerABC;
   var EmperorViewController = viewcontroller.EmperorViewController;
@@ -315,9 +315,10 @@ requirejs([
       var attr = new EmperorAttributeABC(container, 'foo', 'bar',
           this.sharedDecompositionViewDict, {});
 
-      var met = {'biplot': ['SampleID', 'Gram'],
-                  'pcoa': ['SampleID', 'LinkerPrimerSequence', 'Treatment',
-                           'DOB']};
+
+      var met = {"biplot": ["Gram", "SampleID"],
+                 "pcoa": ["DOB", "LinkerPrimerSequence", "SampleID",
+                          "Treatment"]};
 
       deepEqual(attr._metadata, met);
     });
@@ -396,7 +397,7 @@ requirejs([
       var container = $('<div id="does-not-exist"></div>');
       var attr = new EmperorAttributeABC(container, 'foo', 'bar',
                                          {'scatter': dv}, {});
-      equal(attr.getMetadataField(), 'SampleID');
+      equal(attr.getMetadataField(), 'Gram');
     });
 
     /**
@@ -409,8 +410,8 @@ requirejs([
       var container = $('<div id="does-not-exist"></div>');
       var attr = new EmperorAttributeABC(container, 'foo', 'bar',
                                          {'scatter': dv}, {});
-      attr.setMetadataField('Gram');
-      equal(attr.getMetadataField(), 'Gram');
+      attr.setMetadataField('SampleID');
+      equal(attr.getMetadataField(), 'SampleID');
     });
 
 
@@ -469,14 +470,67 @@ requirejs([
         // modify the decomposition view dictionary
         shared.biplot = scope.sharedDecompositionViewDict.biplot;
 
-        deepEqual(attr._metadata, {'scatter': ['SampleID',
-                                               'LinkerPrimerSequence',
-                                               'Treatment', 'DOB']});
+        deepEqual(attr._metadata, {'scatter': ['DOB', 'LinkerPrimerSequence',
+                                               'SampleID', 'Treatment']});
         attr.refreshMetadata();
-        deepEqual(attr._metadata, {'scatter': ['SampleID',
-                                               'LinkerPrimerSequence',
-                                               'Treatment', 'DOB'],
-                                   'biplot': ['SampleID', 'Gram']});
+        deepEqual(attr._metadata, {'scatter': ['DOB', 'LinkerPrimerSequence',
+                                               'SampleID', 'Treatment'],
+                                   'biplot': ['Gram', 'SampleID']});
+
+        start(); // qunit
+      });
+    });
+
+    /**
+     *
+     * Test setEnabled (false)
+     *
+     */
+    asyncTest('Test setEnabled false', function() {
+      var dv = new DecompositionView(this.decomp);
+      var container = $('<div id="does-not-exist"></div>');
+      var attr = new EmperorAttributeABC(container, 'foo', 'bar',
+                                         {'scatter': dv}, {});
+      $(function() {
+        // disable
+        attr.setEnabled(false);
+
+        equal(attr.enabled, false);
+        equal(attr.$select.is(':disabled'), true);
+        equal(attr.bodyGrid.getOptions().editable, false);
+
+        // enable
+        attr.setEnabled(true);
+
+        equal(attr.enabled, true);
+        equal(attr.$select.is(':disabled'), false);
+        equal(attr.bodyGrid.getOptions().editable, true);
+
+        start(); // qunit
+      });
+    });
+
+    /**
+     *
+     * Test setEnabled (true)
+     *
+     */
+    asyncTest('Test setEnabled true', function() {
+      var dv = new DecompositionView(this.decomp);
+      var container = $('<div id="does-not-exist"></div>');
+      var attr = new EmperorAttributeABC(container, 'foo', 'bar',
+                                         {'scatter': dv}, {});
+      $(function() {
+        // Controllers should be enabled
+        equal(attr.enabled, true);
+        equal(attr.$select.is(':disabled'), false);
+        equal(attr.bodyGrid.getOptions().editable, true);
+
+        // and they should remain the same after "enabling" them again
+        attr.setEnabled(true);
+        equal(attr.enabled, true);
+        equal(attr.$select.is(':disabled'), false);
+        equal(attr.bodyGrid.getOptions().editable, true);
 
         start(); // qunit
       });

--- a/tests/javascript_tests/test_view_controller.js
+++ b/tests/javascript_tests/test_view_controller.js
@@ -316,9 +316,9 @@ requirejs([
           this.sharedDecompositionViewDict, {});
 
 
-      var met = {"biplot": ["Gram", "SampleID"],
-                 "pcoa": ["DOB", "LinkerPrimerSequence", "SampleID",
-                          "Treatment"]};
+      var met = {'biplot': ['Gram', 'SampleID'],
+                 'pcoa': ['DOB', 'LinkerPrimerSequence', 'SampleID',
+                          'Treatment']};
 
       deepEqual(attr._metadata, met);
     });
@@ -543,7 +543,7 @@ requirejs([
      */
     asyncTest('Test large dataset', function() {
       var coords = [], metadata = [];
-      for (var i = 0; i < 1001; i++){
+      for (var i = 0; i < 1001; i++) {
         coords.push([Math.random(), Math.random(), Math.random(),
                      Math.random()]);
         metadata.push([i, 'b ' + Math.random(), 'c ' + Math.random()]);
@@ -555,7 +555,7 @@ requirejs([
       var dv = new DecompositionView(d);
       var container = $('<div id="does-not-exist"></div>');
       // create a dummy category selection callback
-      var options = {'categorySelectionCallback': function(){}};
+      var options = {'categorySelectionCallback': function() {}};
       var attr = new EmperorAttributeABC(container, 'foo', 'bar',
                                          {'scatter': dv}, options);
       $(function() {

--- a/tests/javascript_tests/test_view_controller.js
+++ b/tests/javascript_tests/test_view_controller.js
@@ -405,15 +405,17 @@ requirejs([
      * Test set metadata field
      *
      */
-    test('Test getMetadataField', function() {
+    test('Test setMetadataField', function() {
       var dv = new DecompositionView(this.decomp);
       var container = $('<div id="does-not-exist"></div>');
       var attr = new EmperorAttributeABC(container, 'foo', 'bar',
                                          {'scatter': dv}, {});
       attr.setMetadataField('SampleID');
       equal(attr.getMetadataField(), 'SampleID');
-    });
 
+      attr.setMetadataField(null);
+      equal(attr.getMetadataField(), null);
+    });
 
     /**
      *

--- a/tests/javascript_tests/test_visibility_controller.js
+++ b/tests/javascript_tests/test_visibility_controller.js
@@ -91,7 +91,7 @@ requirejs([
       equal(testColumn.field, 'value');
 
       // verify the visibility value is set properly
-      equal(controller.$select.val(), 'DOB');
+      equal(controller.getMetadataField(), null);
     });
 
     test('Testing setPlottableAttributes helper function', function(assert) {
@@ -121,6 +121,7 @@ requirejs([
       var controller = new VisibilityController(container,
           this.sharedDecompositionViewDict);
 
+      controller.setMetadataField('DOB');
       var obs = controller.toJSON();
       var exp = {category: 'DOB', data: {'20070314': true, '20071112': true}};
       deepEqual(obs, exp);

--- a/tests/javascript_tests/test_visibility_controller.js
+++ b/tests/javascript_tests/test_visibility_controller.js
@@ -140,6 +140,31 @@ requirejs([
       equal(controller.decompViewDict.scatter.markers[idx + 1].visible, true);
     });
 
+    test('Testing toJSON', function() {
+      var container = $('<div id="does-not-exist" style="height:11px; ' +
+                        'width:12px"></div>');
+      var controller = new VisibilityController(container,
+          this.sharedDecompositionViewDict);
+      controller.setMetadataField(null);
+
+      var obs = controller.toJSON();
+      var exp = {category: null, data: {}};
+      deepEqual(obs, exp);
+    });
+
+    test('Testing fromJSON', function() {
+      var json = {category: null,
+                  data: {}};
+      var container = $('<div id="does-not-exist" style="height:11px; ' +
+                        'width:12px"></div>');
+      var controller = new VisibilityController(container,
+          this.sharedDecompositionViewDict);
+      controller.fromJSON(json);
+
+      equal(controller.decompViewDict.scatter.markers[0].visible, true);
+      equal(controller.decompViewDict.scatter.markers[1].visible, true);
+    });
+
   });
 
 });

--- a/tests/javascript_tests/test_visibility_controller.js
+++ b/tests/javascript_tests/test_visibility_controller.js
@@ -91,7 +91,7 @@ requirejs([
       equal(testColumn.field, 'value');
 
       // verify the visibility value is set properly
-      equal(controller.$select.val(), 'SampleID');
+      equal(controller.$select.val(), 'DOB');
     });
 
     test('Testing setPlottableAttributes helper function', function(assert) {
@@ -122,7 +122,7 @@ requirejs([
           this.sharedDecompositionViewDict);
 
       var obs = controller.toJSON();
-      var exp = {category: 'SampleID', data: {'PC.636': true, 'PC.635': true}};
+      var exp = {category: 'DOB', data: {'20070314': true, '20071112': true}};
       deepEqual(obs, exp);
     });
 


### PR DESCRIPTION
When matrices with more than 1000 samples are loaded in emperor, none of the tabs are "active" (meaning that there is no table of colors, shapes, scales, etc) until a metadata category is selected for each of the controllers. After a metadata category is selected, the grid with the colors, shapes or scales is displayed, and the program should continue to work as usual.

Making these changes allows us to load the EMP (~30K samples) in about 7-10 seconds, the memory consumption is greatly reduced and the overall experience is smoother.

In making these changes, I had to make a few additional changes:

- Sort metadata headers alphabetically.
- Make the `setEnabled` method disable the widgets in the current view controller.
- Allow for `setMetadataField` to take `null` as a parameter, this in turn resets the class' attribute to its default state (for example in `ColorViewController` all markers are changed back to red, in `ScaleViewController` all markers are changed back to have a scale of 1, etc).
- Allow fromJSON and toJSON to deal with `null` values.
- Add tests for all these changes 📓.
