### PR TITLE
BUG: Fix problem with axes labels

### DIFF
--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -175,9 +175,10 @@ define([
   AxesController.prototype._buildScreePlot = function() {
     var scope = this;
     var percents = this.getView().decomp.percExpl;
+    var names = this.getView().decomp.axesNames;
     percents = _.map(percents, function(val, index) {
       // +1 to account for zero-indexing
-      return {'axis': 'PC ' + (index + 1), 'percent': val,
+      return {'axis': names[index] + ' ', 'percent': val,
               'dimension-index': index};
     });
 
@@ -216,6 +217,10 @@ define([
       .append('g');
 
     this.$_screePlotContainer.height(height + margin.top + margin.bottom);
+
+    // Only keep dimensions resulting of an ordination i.e. with a positive
+    // percentage explained.
+    percents = percents.filter(function(x) { return x.percent >= 0; });
 
     // creation of the chart itself
     x.domain(percents.map(function(d) { return d.axis; }));

--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -51,7 +51,7 @@ define([
                 allowEmpty: false,
                 showInitial: true,
                 clickoutFiresChange: true,
-                hideAfterPaletteSelect:true,
+                hideAfterPaletteSelect: true,
                 change: function(color) {
                   // We let the controller deal with the callback, the only
                   // things we need are the name of the element triggering
@@ -205,12 +205,12 @@ define([
       scope.flipAxis(visibleDimension);
     });
 
-    $(function(){
+    $(function() {
       $menu.val(decomposition.axesNames[visibleDimension]);
     });
 
     return {menu: $menu, checkbox: $check};
-  }
+  };
 
   /**
    * Method to build the scree plot and updates the interface appropriately.

--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -130,41 +130,79 @@ define([
     }
 
     var view = this.getView(), scope = this;
-    var percents = view.decomp.percExpl;
+    var $table = $('<table></table>'), $row, $td, widgets;
     var names = ['First', 'Second', 'Third'];
 
-    var table = '<table style="border:none;">';
-    table += '<col align="left"><col align="right"><col align="center">';
+    $table.css({'border': 'none',
+                'width': 'inherit',
+                'text-align': 'left',
+                'padding-bottom': '10%'});
+
+    $table.append('<tr><th>Axis</th><th>Visible</th><th>Invert</th></tr>');
+
     _.each(view.visibleDimensions, function(dimension, index) {
-      table += '<tr>';
+      widgets = scope._makeDimensionWidgets(index);
+
+      $row = $('<tr></tr>');
 
       // axis name
-      table += '<td>' + names[index] + ' Axis' + '</td>';
+      $row.append('<td>' + names[index] + '</td>');
 
-      // percentage of variation and name
-      table += '<td>PC ' + (dimension + 1) + ' - ' +
-               percents[dimension].toFixed(2) + '%</td>';
+      // visible dimension menu
+      $td = $('<td></td>');
+      $td.append(widgets.menu);
+      $row.append($td);
 
-      // whether or not the axis is flipped
-      table += '<td>Is' + (scope._flippedAxes[index] ? '' : ' Not') +
-               ' Flipped</td>';
+      // inverted checkbox
+      $td = $('<td></td>');
+      $td.append(widgets.checkbox);
+      $row.append($td);
 
-      table += '</tr>';
-
-    });
-    table += '</table>';
-
-    this.$table = $(table);
-    this.$table.css({'width': 'inherit',
-                     'padding-bottom': '10%'
+      $table.append($row);
     });
 
+    this.$table = $table;
     this.$header.append(this.$table);
 
     // the jupyter notebook adds style on the tables, so remove it
     this.$header.find('tr').css('border', 'none');
     this.$header.find('td').css('border', 'none');
   };
+
+  /**
+   *
+   *
+   *
+   */
+  AxesController.prototype._makeDimensionWidgets = function(position) {
+    var scope = this, $check, $menu;
+    var decomposition = scope.getView().decomp;
+    var visibleDimension = scope.getView().visibleDimensions[position];
+
+    $menu = $('<select>');
+    $check = $('<input type="checkbox">');
+
+    $check.prop('checked', scope._flippedAxes[visibleDimension]);
+
+    _.each(decomposition.axesNames, function(name, index) {
+      $menu.append($('<option>').attr('value', name).text(name));
+    });
+
+    $menu.on('change', function() {
+      var index = $(this).prop('selectedIndex');
+      scope.updateVisibleAxes(decomposition.axesNames[index], position);
+    });
+
+    $check.on('change', function() {
+      scope.flipAxis(visibleDimension);
+    });
+
+    $(function(){
+      $menu.val(decomposition.axesNames[visibleDimension]);
+    });
+
+    return {menu: $menu, checkbox: $check};
+  }
 
   /**
    * Method to build the scree plot and updates the interface appropriately.

--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -39,7 +39,7 @@ define([
     colors += '</table>';
     this.$body.append(colors);
 
-    // the jupyter notebook add style on the tables, so remove it
+    // the jupyter notebook adds style on the tables, so remove it
     this.$body.find('tr').css('border', 'none');
     this.$body.find('td').css('border', 'none');
 
@@ -53,7 +53,7 @@ define([
                 clickoutFiresChange: true,
                 change: function(color) {
                   // We let the controller deal with the callback, the only
-                  // things we need are the name of the element triggerring
+                  // things we need are the name of the element triggering
                   // the color change and the color as an integer (note that
                   // we are parsing from a string hence we have to indicate
                   // the numerical base)
@@ -160,7 +160,7 @@ define([
 
     this.$header.append(this.$table);
 
-    // the jupyter notebook add style on the tables, so remove it
+    // the jupyter notebook adds style on the tables, so remove it
     this.$header.find('tr').css('border', 'none');
     this.$header.find('td').css('border', 'none');
   };

--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -189,7 +189,8 @@ define([
     $menu = $('<select>');
     $check = $('<input type="checkbox">');
 
-    $check.prop('checked', scope._flippedAxes[visibleDimension]);
+    // if the axis is flipped, then show the checkmark
+    $check.prop('checked', scope._flippedAxes[position]);
 
     _.each(decomposition.axesNames, function(name, index) {
       $menu.append($('<option>').attr('value', name).text(name));
@@ -197,7 +198,7 @@ define([
 
     $menu.on('change', function() {
       var index = $(this).prop('selectedIndex');
-      scope.updateVisibleAxes(decomposition.axesNames[index], position);
+      scope.updateVisibleAxes(index, position);
     });
 
     $check.on('change', function() {

--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -320,61 +320,6 @@ define([
       .style('shape-rendering', 'crispEdges');
 
     this.screePlot = svg;
-
-    // This function creates a function callbacks
-    //
-    // The rationale to create this function, was to deal with the fact that
-    // three of the 'context menu' options had the same behaviour, otherwise
-    // we would have had to repeat the code in the returned function.
-    //
-    var callbackFactory = function(callBackIndex) {
-      return (function(key, opts) {
-        var index = parseInt($(this).attr('dimension-index'));
-        scope.updateVisibleAxes(index, callBackIndex);
-      });
-    };
-
-    /*
-      Once we have created the plot, we bind each of the bars to a context
-      menu, hence the selector searches for all the 'rect' tags inside the
-      controller's div.
-
-      The functionality itself is rather simple, each of the options in the
-      context menu allows the user to select the clicked bar as the first,
-      second or third visible axis. With each of these changes, we re-build the
-      display table to reflect the currently visible data (see
-      callbackFactory).
-
-      Finally, there is one option that allows users to reorient the
-      coordinates for that axis.
-     */
-    $.contextMenu({
-      selector: '#' + this.identifier + ' rect',
-      trigger: 'left',
-      items: {
-        'first-axis': {
-          name: 'Set as first axis',
-          callback: callbackFactory(0)
-        },
-        'second-axis': {
-          name: 'Set as second axis',
-          callback: callbackFactory(1)
-        },
-        'third-axis': {
-          name: 'Set as third axis',
-          callback: callbackFactory(2)
-        },
-        'sep1': '---------',
-        'flip-axis': {
-          icon: 'exchange',
-          name: 'Flip axis orientation',
-          callback: function(key, opts) {
-            var index = parseInt($(this).attr('dimension-index'));
-            scope.flipAxis(index);
-          }
-        }
-      }
-    });
   };
 
   /**

--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -51,6 +51,7 @@ define([
                 allowEmpty: false,
                 showInitial: true,
                 clickoutFiresChange: true,
+                hideAfterPaletteSelect:true,
                 change: function(color) {
                   // We let the controller deal with the callback, the only
                   // things we need are the name of the element triggering

--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -170,11 +170,18 @@ define([
   };
 
   /**
+   * Method to create dropdown menus and checkboxes
    *
+   * @param {Integer} position The position of the axis for which the widgets
+   * are being created.
    *
-   *
+   * @private
    */
   AxesController.prototype._makeDimensionWidgets = function(position) {
+    if (position > 2 || position < 0) {
+      throw Error('Cannot create widgets for position: ' + position);
+    }
+
     var scope = this, $check, $menu;
     var decomposition = scope.getView().decomp;
     var visibleDimension = scope.getView().visibleDimensions[position];

--- a/emperor/support_files/js/model.js
+++ b/emperor/support_files/js/model.js
@@ -397,11 +397,11 @@ function($, _, util) {
 
     if (this.axesNames.length === 0) {
       for (i = 0; i < this.dimensions; i++) {
-        replacement.push(prefix + (i+1));
+        replacement.push(prefix + (i + 1));
       }
       this.axesNames = replacement;
     }
-    else{
+    else {
       names = util.splitNumericValues(this.axesNames);
 
       for (i = 0; i < names.numeric.length; i++) {
@@ -419,7 +419,7 @@ function($, _, util) {
         this.axesNames = names.nonNumeric.concat(replacement);
       }
     }
-  }
+  };
 
   /**
    *

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -401,18 +401,12 @@ define([
 
     this._dimensionsIterator(function(start, end, index) {
 
-      // construct a label of the format: AbbNam (xx.xx %)
-      if (decomp.abbreviatedName !== '') {
-        text = decomp.abbreviatedName;
+      // when the labels get too long, it's a bit hard to look at
+      if (decomp.axesNames[index].length > 25) {
+        text = decomp.axesNames[index].slice(0, 20) + '...';
       }
       else {
-        // when the labels get too long, it's a bit hard to look at
-        if (decomp.axesNames[index].length > 25) {
-          text = decomp.axesNames[index].slice(0, 20) + '...';
-        }
-        else {
-          text = decomp.axesNames[index];
-        }
+        text = decomp.axesNames[index];
       }
 
       // account for custom axes (their percentage explained will be -1 to

--- a/tests/javascript_tests/test_decomposition_model.js
+++ b/tests/javascript_tests/test_decomposition_model.js
@@ -148,7 +148,8 @@ requirejs([
                                          0.140148]);
 
       equal(dm.length, 9, 'Length set correctly');
-      deepEqual(dm.axesNames, []);
+      deepEqual(dm.axesNames, ['pcoa 1', 'pcoa 2', 'pcoa 3', 'pcoa 4', 'pcoa 5',
+                               'pcoa 6', 'pcoa 7', 'pcoa 8']);
     });
 
     /**
@@ -157,10 +158,13 @@ requirejs([
      *
      */
     test('Test axesNames', function() {
-      var names = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+      var names = ['PC 1', 'PC 2', 'PC 3', 'PC 4', 'PC 5', 'PC 6', 'PC 7',
+                   'PC 8', 'PC 9'];
       var dm = new DecompositionModel(name, ids, coords, pct_var, md_headers,
           metadata, names);
-      deepEqual(dm.axesNames, names, 'Plottable retrieved successfully');
+      deepEqual(dm.axesNames,
+                ['PC 1', 'PC 2', 'PC 3', 'PC 4', 'PC 5', 'PC 6', 'PC 7',
+                 'PC 8', 'PC 9'], 'Axes correctly renamed');
     });
 
     /**
@@ -600,6 +604,47 @@ requirejs([
       var exp = ['PC.636', 'PC.635', 'PC.356', 'PC.481', 'PC.354', 'PC.593',
       'PC.355', 'PC.607', 'PC.634'];
       deepEqual(obs, exp, 'Apply works as expected');
+    });
+
+    /**
+     *
+     * Test axes names are fixed appropriately.
+     *
+     */
+    test('Fix axes names for scikit-bio', function(){
+      var names = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+      var expected = ['pcoa 1', 'pcoa 2', 'pcoa 3', 'pcoa 4', 'pcoa 5',
+                      'pcoa 6', 'pcoa 7', 'pcoa 8', 'pcoa 9'];
+      var dm = new DecompositionModel(name, ids, coords, pct_var, md_headers,
+                                      metadata, names);
+      deepEqual(dm.axesNames, expected, 'Integer names replaced correctly');
+    });
+
+    /**
+     *
+     * Test axes names are fixed appropriately with custom axes.
+     *
+     */
+    test('Fix axes names for scikit-bio (custom axes)', function(){
+      var names = ['days', 'ph', 0, 1, 2, 3, 4, 5, 6];
+      var expected = ['days', 'ph', 'Axis 1', 'Axis 2', 'Axis 3', 'Axis 4',
+                      'Axis 5', 'Axis 6', 'Axis 7'];
+      var dm = new DecompositionModel('', ids, coords, pct_var, md_headers,
+                                      metadata, names);
+      deepEqual(dm.axesNames, expected, 'Custon axes fixed correctly');
+    });
+
+    /**
+     *
+     * Test axes names are not modified because they don't match scikit-bio
+     *
+     */
+    test('Do not fix axes names for scikit-bio', function(){
+      var names = ['days', 'ph', 0, 1, 20, 3, 4, 5, 6];
+      var expected = ['days', 'ph', 0, 1, 20, 3, 4, 5, 6];
+      var dm = new DecompositionModel('', ids, coords, pct_var, md_headers,
+                                      metadata, names);
+      deepEqual(dm.axesNames, expected, 'No changes are made');
     });
 
     /**

--- a/tests/javascript_tests/test_decomposition_model.js
+++ b/tests/javascript_tests/test_decomposition_model.js
@@ -611,7 +611,7 @@ requirejs([
      * Test axes names are fixed appropriately.
      *
      */
-    test('Fix axes names for scikit-bio', function(){
+    test('Fix axes names for scikit-bio', function() {
       var names = [0, 1, 2, 3, 4, 5, 6, 7, 8];
       var expected = ['pcoa 1', 'pcoa 2', 'pcoa 3', 'pcoa 4', 'pcoa 5',
                       'pcoa 6', 'pcoa 7', 'pcoa 8', 'pcoa 9'];
@@ -625,7 +625,7 @@ requirejs([
      * Test axes names are fixed appropriately with custom axes.
      *
      */
-    test('Fix axes names for scikit-bio (custom axes)', function(){
+    test('Fix axes names for scikit-bio (custom axes)', function() {
       var names = ['days', 'ph', 0, 1, 2, 3, 4, 5, 6];
       var expected = ['days', 'ph', 'Axis 1', 'Axis 2', 'Axis 3', 'Axis 4',
                       'Axis 5', 'Axis 6', 'Axis 7'];
@@ -639,7 +639,7 @@ requirejs([
      * Test axes names are not modified because they don't match scikit-bio
      *
      */
-    test('Do not fix axes names for scikit-bio', function(){
+    test('Do not fix axes names for scikit-bio', function() {
       var names = ['days', 'ph', 0, 1, 20, 3, 4, 5, 6];
       var expected = ['days', 'ph', 0, 1, 20, 3, 4, 5, 6];
       var dm = new DecompositionModel('', ids, coords, pct_var, md_headers,


### PR DESCRIPTION
Label names are now fixed to account for scikit-bio's OrdinationResults IO
module. The UI for the axes names has now changed to allow users to click on
menus and checkboxes (like in the previous version of emperor) instead of
clicking on the scree plot.

The variation explained by each axis is now shown **only** for non-custom axes.

While the scree plot interaction was *fun*, I think it was a bit confusing, so
I think this is better.

Fixes #562