### PR TITLE
BUG: Resolve stable URLs depending on package version

### DIFF
--- a/emperor/__init__.py
+++ b/emperor/__init__.py
@@ -35,7 +35,7 @@ Functions
 # ----------------------------------------------------------------------------
 
 import pkg_resources
-__version__ = pkg_resources.get_distribution('emperor').version
+__version__ = pkg_resources.get_distribution('emperor').version  # noqa
 
 from emperor.core import Emperor
 from emperor._pandas import scatterplot

--- a/emperor/__init__.py
+++ b/emperor/__init__.py
@@ -35,12 +35,12 @@ Functions
 # ----------------------------------------------------------------------------
 
 import pkg_resources
+__version__ = pkg_resources.get_distribution('emperor').version
 
 from emperor.core import Emperor
 from emperor._pandas import scatterplot
 from emperor.util import nbinstall
 
-__version__ = pkg_resources.get_distribution('emperor').version
 
 __all__ = ['Emperor', 'scatterplot', 'biplots', 'format', 'filter', 'parse',
            'sort', 'util', 'nbinstall']

--- a/emperor/core.py
+++ b/emperor/core.py
@@ -30,14 +30,15 @@ import numpy as np
 from jinja2 import FileSystemLoader
 from jinja2.environment import Environment
 
+from emperor import __version__ as emperor_version
 from emperor.util import (get_emperor_support_files_dir,
-                          validate_and_process_custom_axes)
+                          validate_and_process_custom_axes, resolve_stable_url)
 from emperor.qiime_backports.make_3d_plots import (get_custom_coords,
                                                    remove_nans,
                                                    scale_custom_coords)
 
 # we are going to use this remote location to load external resources
-REMOTE_URL = ('https://cdn.rawgit.com/biocore/emperor/new-api/emperor'
+REMOTE_URL = ('https://cdn.rawgit.com/biocore/emperor/%s/emperor'
               '/support_files')
 LOCAL_URL = "/nbextensions/emperor/support_files"
 
@@ -192,7 +193,8 @@ class Emperor(object):
 
         if isinstance(remote, bool):
             if remote:
-                self.base_url = REMOTE_URL
+                self.base_url = resolve_stable_url(emperor_version,
+                                                   REMOTE_URL)
             else:
                 self.base_url = LOCAL_URL
         elif isinstance(remote, str):

--- a/emperor/util.py
+++ b/emperor/util.py
@@ -704,3 +704,33 @@ def validate_and_process_custom_axes(mf, custom_axes):
         mf[axis] = temp
 
     return mf
+
+
+def resolve_stable_url(version, base_url):
+    """Resolve a stable URL for release versions of Emperor
+
+    If the plot is produced using a release version of Emperor, then we
+    point the URL to the release version, otherwise we point to the
+    development version of Emperor.
+
+    Parameters
+    ----------
+    version : str
+        Current version of emperor.
+    base_url : str
+        The URL where we pull resources from.
+
+
+    Returns
+    -------
+    str
+        A URL that points to the emperor's resources.
+    """
+    if version.endswith("dev"):
+        # this will need to be fixed when new-api is merged to master
+        return base_url % 'new-api'
+    else:
+        # version names are changed for git tags from betaxx to -beta.xx
+        if 'b' in version:
+            version = version.replace('b', '-beta.')
+        return base_url % version

--- a/emperor/util.py
+++ b/emperor/util.py
@@ -9,6 +9,7 @@ from __future__ import division
 
 import pandas as pd
 import numpy as np
+import warnings
 
 from os import listdir
 from os.path import abspath, dirname, join, isdir
@@ -33,6 +34,11 @@ class EmperorInputFilesError(IOError):
 
 class EmperorUnsupportedComputation(ValueError):
     """Exception for computations that lack a meaning"""
+    pass
+
+
+class EmperorWarning(UserWarning):
+    """Generic package warning"""
     pass
 
 
@@ -724,8 +730,18 @@ def resolve_stable_url(version, base_url):
     -------
     str
         A URL that points to the emperor's resources.
+
+    Notes
+    -----
+    An EmperorWarning is shown when development URLs are used.
     """
     if 'dev' in version:
+        warnings.warn("Plots generated with `remote=True` using a development "
+                      "version of Emperor, may fail to load in the future "
+                      "(only the logo may be displayed instead of the plot). "
+                      "To avoid this, use a release version of Emperor.",
+                      EmperorWarning)
+
         # this will need to be fixed when new-api is merged to master
         return base_url % 'new-api'
     else:

--- a/emperor/util.py
+++ b/emperor/util.py
@@ -726,7 +726,7 @@ def resolve_stable_url(version, base_url):
     str
         A URL that points to the emperor's resources.
     """
-    if version.endswith("dev"):
+    if 'dev' in version:
         # this will need to be fixed when new-api is merged to master
         return base_url % 'new-api'
     else:

--- a/emperor/util.py
+++ b/emperor/util.py
@@ -720,7 +720,6 @@ def resolve_stable_url(version, base_url):
     base_url : str
         The URL where we pull resources from.
 
-
     Returns
     -------
     str

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -45,6 +45,12 @@ class TopLevelTests(TestCase):
         self.mf.set_index('SampleID', inplace=True)
         self.files_to_remove = []
 
+        # note that we don't test with remote=True because the url is resolved
+        # by emperor.util.resolve_stable_url, so it is bound to change depending
+        # on the environment executing the test
+        self.url = ('https://cdn.rawgit.com/biocore/emperor/new-api/emperor/'
+                    'support_files')
+
         np.random.seed(111)
 
     def tearDown(self):
@@ -61,7 +67,7 @@ class TopLevelTests(TestCase):
         self.assertEqual(emp.height, '111px')
 
     def test_str(self):
-        emp = Emperor(self.ord_res, self.mf)
+        emp = Emperor(self.ord_res, self.mf, remote=self.url)
 
         self.assertEqual(emp.width, '100%')
         self.assertEqual(emp.height, '500px')
@@ -87,7 +93,7 @@ class TopLevelTests(TestCase):
 
     def test_unnamed_index(self):
         self.mf.index.name = None
-        emp = Emperor(self.ord_res, self.mf)
+        emp = Emperor(self.ord_res, self.mf, remote=self.url)
         obs = str(emp)
 
         try:
@@ -139,7 +145,7 @@ class TopLevelTests(TestCase):
         self.files_to_remove.append('./something-else')
 
     def test_custom_axes(self):
-        emp = Emperor(self.ord_res, self.mf)
+        emp = Emperor(self.ord_res, self.mf, remote=self.url)
         obs = emp.make_emperor(custom_axes=['DOB'])
 
         try:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -46,8 +46,8 @@ class TopLevelTests(TestCase):
         self.files_to_remove = []
 
         # note that we don't test with remote=True because the url is resolved
-        # by emperor.util.resolve_stable_url, so it is bound to change depending
-        # on the environment executing the test
+        # by emperor.util.resolve_stable_url, so it is bound to change
+        # depending on the environment executing the test
         self.url = ('https://cdn.rawgit.com/biocore/emperor/new-api/emperor/'
                     'support_files')
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -55,8 +55,8 @@ class TopLevelTests(TestCase):
         self.samples = pd.DataFrame(data=x, index=ind, columns=cols)
 
         # note that we don't test with remote=True because the url is resolved
-        # by emperor.util.resolve_stable_url, so it is bound to change depending
-        # on the environment executing the test
+        # by emperor.util.resolve_stable_url, so it is bound to change
+        # depending on the environment executing the test
         self.url = ('https://cdn.rawgit.com/biocore/emperor/new-api/emperor/'
                     'support_files')
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -54,13 +54,17 @@ class TopLevelTests(TestCase):
         cols = pd.Index(['num_1', 'num_4', 'num_3', 'num_2'], dtype='object')
         self.samples = pd.DataFrame(data=x, index=ind, columns=cols)
 
+        # note that we don't test with remote=True because the url is resolved
+        # by emperor.util.resolve_stable_url, so it is bound to change depending
+        # on the environment executing the test
+        self.url = ('https://cdn.rawgit.com/biocore/emperor/new-api/emperor/'
+                    'support_files')
+
     def test_scatterplot(self):
         emp = scatterplot(self.df)
 
         self.assertTrue(isinstance(emp, Emperor))
         self.assertEqual(emp.dimensions, 4)
-        self.assertEqual(emp.base_url, 'https://cdn.rawgit.com/biocore/'
-                         'emperor/new-api/emperor/support_files')
 
         pd.util.testing.assert_frame_equal(self.df, emp.mf)
 
@@ -68,7 +72,8 @@ class TopLevelTests(TestCase):
                                            self.samples)
 
     def test_scatterplot_reordered(self):
-        emp = scatterplot(self.df, x='num_3', y='num_2', z='num_1')
+        emp = scatterplot(self.df, x='num_3', y='num_2', z='num_1',
+                          remote=self.url)
 
         self.assertTrue(isinstance(emp, Emperor))
         self.assertEqual(emp.dimensions, 4)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -571,6 +571,11 @@ class TopLevelTests(TestCase):
         obs = resolve_stable_url('1.0.0b7-dev', url)
         self.assertEqual(obs, url % 'new-api')
 
+    def test_resolve_stable_url_development_number(self):
+        url = 'https://github.com/biocore/emperor/%s/emperor/support_files'
+        obs = resolve_stable_url('1.0.0b7-dev0', url)
+        self.assertEqual(obs, url % 'new-api')
+
 
 MAPPING_FILE_DATA = [
     ['PC.354', 'AGCACGAGCCTA', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20061218',

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,6 +13,7 @@ from shutil import rmtree
 from tempfile import gettempdir
 
 import pandas as pd
+import warnings
 from numpy import array
 from numpy.testing import assert_almost_equal
 
@@ -22,7 +23,10 @@ from emperor.util import (keep_columns_from_mapping_file,
                           fill_mapping_field_from_mapping_file,
                           sanitize_mapping_file, guess_coordinates_files,
                           nbinstall, validate_and_process_custom_axes,
-                          resolve_stable_url)
+                          resolve_stable_url, EmperorWarning)
+
+
+warnings.simplefilter('always', category=EmperorWarning)
 
 
 class TopLevelTests(TestCase):
@@ -562,19 +566,32 @@ class TopLevelTests(TestCase):
             validate_and_process_custom_axes(mf, ['louie', 'dewey'])
 
     def test_resolve_stable_url_release(self):
+        # we test that no warnings are raised
         url = 'https://github.com/biocore/emperor/%s/emperor/support_files'
-        obs = resolve_stable_url('1.0.0b7', url)
-        self.assertEqual(obs, url % '1.0.0-beta.7')
+        with warnings.catch_warnings(record=True) as w:
+            obs = resolve_stable_url('1.0.0b7', url)
+            self.assertTrue(len(w) == 0)
+            self.assertEqual(obs, url % '1.0.0-beta.7')
 
-    def test_resolve_stable_url_development(self):
+    def test_resolve_stable_url_release_check_warning(self):
         url = 'https://github.com/biocore/emperor/%s/emperor/support_files'
-        obs = resolve_stable_url('1.0.0b7-dev', url)
-        self.assertEqual(obs, url % 'new-api')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            obs = resolve_stable_url('1.0.0b7-dev', url)
 
-    def test_resolve_stable_url_development_number(self):
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, EmperorWarning))
+            self.assertEqual(obs, url % 'new-api')
+
+    def test_resolve_stable_url_release_number_check_warning(self):
         url = 'https://github.com/biocore/emperor/%s/emperor/support_files'
-        obs = resolve_stable_url('1.0.0b7-dev0', url)
-        self.assertEqual(obs, url % 'new-api')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            obs = resolve_stable_url('1.0.0b7-dev0', url)
+
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, EmperorWarning))
+            self.assertEqual(obs, url % 'new-api')
 
 
 MAPPING_FILE_DATA = [

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,7 +21,8 @@ from emperor.util import (keep_columns_from_mapping_file,
                           EmperorInputFilesError,
                           fill_mapping_field_from_mapping_file,
                           sanitize_mapping_file, guess_coordinates_files,
-                          nbinstall, validate_and_process_custom_axes)
+                          nbinstall, validate_and_process_custom_axes,
+                          resolve_stable_url)
 
 
 class TopLevelTests(TestCase):
@@ -559,6 +560,16 @@ class TopLevelTests(TestCase):
 
         with self.assertRaises(ValueError):
             validate_and_process_custom_axes(mf, ['louie', 'dewey'])
+
+    def test_resolve_stable_url_release(self):
+        url = 'https://github.com/biocore/emperor/%s/emperor/support_files'
+        obs = resolve_stable_url('1.0.0b7', url)
+        self.assertEqual(obs, url % '1.0.0-beta.7')
+
+    def test_resolve_stable_url_development(self):
+        url = 'https://github.com/biocore/emperor/%s/emperor/support_files'
+        obs = resolve_stable_url('1.0.0b7-dev', url)
+        self.assertEqual(obs, url % 'new-api')
 
 
 MAPPING_FILE_DATA = [


### PR DESCRIPTION
Deals with a problem where plots created with the `remote=True` argument would lead to the plots failing if new dependencies were added.

The base URL is now resolved depending on the version string. I had to change the tests because we can no longer test `remote=True` explicitly as the version string will change dependent of the version.

@wasade, this would deal with the need to update the figures in the deblur-manuscript repo.

------------

#### During code review this point came up

- [x] When `remote=True` is used, the code should raise a warning alerting the user of the possible consequences of these actions.