### PR TITLE
BUG/BLD: Fix problem with labels being clipped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ install:
   - conda create --yes -n env_name python=$TRAVIS_PYTHON_VERSION pip numpy${NUMPY_VERSION} 'scipy>=0.17.0' matplotlib openpyxl=1.8.2 pandas nose flake8 pep8 ipython-notebook
   - source activate env_name
   - pip install https://github.com/google/closure-linter/archive/master.zip
-  - pip install sphinx sphinx-bootstrap-theme coverage coveralls
-  - pip install -e '.[all]' --no-use-wheel
+  - pip install 'sphinx<1.6' sphinx-bootstrap-theme coverage coveralls
+  # install lockfile before to prevent a failure in travis
+  - pip install 'lockfile>=0.10.2'
+  - pip install -e '.[all]' --no-use-wheel --verbose
   - npm install -g jsdoc
 script:
   - flake8 emperor/*.py tests/*.py scripts/*.py setup.py

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -95,7 +95,7 @@ define(['underscore', 'three'], function(_, THREE) {
    **/
   function makeLabel(position, text, color, factor) {
     var canvas = document.createElement('canvas');
-    var size = 512;
+    var size = 1024;
 
     factor = (factor === undefined ? 1 : factor);
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ skbio_2 = "scikit-bio >= 0.4.1, < 0.5.0"
 skbio_3 = "scikit-bio >= 0.4.1"
 base = {"numpy >= 1.7", "scipy >= 0.17.0", "click", "pandas",
         skbio_2, "jinja2 >= 2.9", "future"}
-doc = {"Sphinx >= 1.2.2", "sphinx-bootstrap-theme"}
+doc = {"Sphinx < 1.6", "sphinx-bootstrap-theme"}
 test = {"nose >= 0.10.1", "pep8", "flake8"}
 all_deps = base | doc | test
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ Gigascience. 2013 Nov 26;2(1):16.
 skbio_2 = "scikit-bio >= 0.4.1, < 0.5.0"
 skbio_3 = "scikit-bio >= 0.4.1"
 base = {"numpy >= 1.7", "scipy >= 0.17.0", "click", "pandas",
-        skbio_2, "jinja2", "future"}
+        skbio_2, "jinja2 >= 2.9", "future"}
 doc = {"Sphinx >= 1.2.2", "sphinx-bootstrap-theme"}
 test = {"nose >= 0.10.1", "pep8", "flake8"}
 all_deps = base | doc | test


### PR DESCRIPTION
Reported by @ebolyen, long axes labels would be clipped. To fix this
I've made the font canvas bigger, so that it can at least fit 25
characters, after which it will add `...` at the end of the label (this
logic was already in place but was not noticeable due to the bug).

I've also upped the JINJA2 version to at least be 2.9.
see https://github.com/qiime2/q2-emperor/issues/41