### PR TITLE
ENH: Hide axes labels and lines

### DIFF
--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -48,24 +48,28 @@ define([
                 palette: [['black', 'white']],
                 showPalette: true,
                 showInput: true,
-                allowEmpty: false,
+                allowEmpty: true,
                 showInitial: true,
                 clickoutFiresChange: true,
                 hideAfterPaletteSelect: true,
                 change: function(color) {
-                  // We let the controller deal with the callback, the only
-                  // things we need are the name of the element triggering
-                  // the color change and the color as an integer (note that
-                  // we are parsing from a string hence we have to indicate
-                  // the numerical base)
-                  scope.colorChanged($(this).attr('name'),
-                                     parseInt(color.toHex(), 16));
+                  // null means hide axes and labels
+                  if (color !== null) {
+                    // We let the controller deal with the callback, the only
+                    // things we need are the name of the element triggering
+                    // the color change and the color as an integer (note that
+                    // we are parsing from a string hence we have to indicate
+                    // the numerical base)
+                    color = parseInt(color.toHex(), 16);
+                  }
+                  scope.colorChanged($(this).attr('name'), color);
                 }
     };
     // spectrumify all the elements in the body that have a name ending in
     // color
     this.$body.find('[name="axes-color"]').spectrum(opts);
     opts.color = 'black';
+    opts.allowEmpty = false;
     this.$body.find('[name="background-color"]').spectrum(opts);
 
     /**

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -356,13 +356,18 @@ define([
    *
    * @param {Integer} color An integer in hexadecimal that specifies the color
    * of each of the axes lines, the length of these lines is determined by the
-   * dimensionRanges property.
+   * dimensionRanges property. If the color value is null the lines will be
+   * removed.
    *
    */
   ScenePlotView3D.prototype.drawAxesWithColor = function(color) {
     var scope = this, axisLine;
 
+    // axes lines are removed if the color is null
     this.removeAxes();
+    if (color === null) {
+      return;
+    }
 
     this._dimensionsIterator(function(start, end, index) {
       axisLine = makeLine(start, end, color, 3, false);
@@ -383,15 +388,20 @@ define([
    * each axis.
    *
    * @param {Integer} color An integer in hexadecimal that specifies the color
-   * of the labels, these labels will be positioned at the end of the axes line.
+   * of the labels, these labels will be positioned at the end of the axes
+   * line. If the color value is null the labels will be removed.
    *
    */
   ScenePlotView3D.prototype.drawAxesLabelsWithColor = function(color) {
     var scope = this, axisLabel, decomp, firstKey, text, factor;
 
-    factor = (this.dimensionRanges.max[0] - this.dimensionRanges.min[0]) * 0.9;
-
+    // the labels are only removed if the color is null
     this.removeAxesLabels();
+    if (color === null) {
+      return;
+    }
+
+    factor = (this.dimensionRanges.max[0] - this.dimensionRanges.min[0]) * 0.9;
 
     // get the first decomposition object, it doesn't really mater which one
     // we look at though, as all of them should have the same percentage

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -187,7 +187,7 @@ requirejs([
       spv.control.dispose();
     });
 
-    test('Test the draw axes', function(assert) {
+    test('Test draw axes', function(assert) {
       // We will use SVGRenderer here and in the other tests as we cannot use
       // WebGLRenderer and test with phantom.js
       var renderer = new THREE.SVGRenderer({antialias: true});
@@ -204,6 +204,27 @@ requirejs([
         equal(line.material.color.r, 0);
         equal(line.material.color.g, 1);
         equal(line.material.color.b, 0.058823529411764705);
+      }
+
+      // release the control back to the main page
+      spv.control.dispose();
+    });
+
+    test('Test axes color as null', function(assert) {
+      // We will use SVGRenderer here and in the other tests as we cannot use
+      // WebGLRenderer and test with phantom.js
+      var renderer = new THREE.SVGRenderer({antialias: true});
+      var spv = new ScenePlotView3D(renderer, this.sharedDecompositionViewDict,
+                                    'fooligans', 0, 0, 20, 20);
+
+      // color the axis lines
+      spv.drawAxesWithColor(null);
+
+      var line;
+
+      for (var i = 0; i < 3; i++) {
+        line = spv.scene.getObjectByName('emperor-axis-line-' + i);
+        equal(line, undefined);
       }
 
       // release the control back to the main page
@@ -256,6 +277,25 @@ requirejs([
         equal(label.material.color.r, 0);
         equal(label.material.color.g, 1);
         equal(label.material.color.b, 0.058823529411764705);
+      }
+
+      // release the control back to the main page
+      spv.control.dispose();
+    });
+
+    test('Test the draw axes labels as null', function(assert) {
+      // We will use SVGRenderer here and in the other tests as we cannot use
+      // WebGLRenderer and test with phantom.js
+      var renderer = new THREE.SVGRenderer({antialias: true});
+      var spv = new ScenePlotView3D(renderer, this.sharedDecompositionViewDict,
+                                    'fooligans', 0, 0, 20, 20);
+
+      // color the axis lines
+      spv.drawAxesLabelsWithColor(null);
+
+      for (var i = 0; i < 3; i++) {
+        label = spv.scene.getObjectByName('emperor-axis-label-' + i);
+        equal(label, undefined);
       }
 
       // release the control back to the main page


### PR DESCRIPTION
The color slector for the axes labels and lines can now be set to empty
(or null), this results in the labels and lines to be hidden. This PR also
adds the appropriate tests.

See animated gif:

![quick](https://user-images.githubusercontent.com/375307/28443336-3606cbfa-6d6a-11e7-98cb-952fca0caf3f.gif)


Fixes #248.