### PR TITLE
Adds a banner with number of visible elements

### DIFF
--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -93,7 +93,7 @@ define([
      * Div with the number of visible samples
      * @type {node}
      */
-    this.$plotBanner = $("<label>Loading ...</label>");
+    this.$plotBanner = $('<label>Loading ...</label>');
     this.$plotBanner.css({'padding': '2px',
                           'font-style': '9pt helvetica',
                           'color': 'white',
@@ -391,11 +391,11 @@ define([
 
     this.$plotBanner.css({'color': color, 'border-color': color});
     this.$plotBanner.html(visible + '/' + total + ' visible');
-  }
+  };
 
   EmperorController.prototype.getPlotBanner = function(text) {
     return this.$plotBanner.text();
-  }
+  };
 
   /**
    *

--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -90,6 +90,21 @@ define([
     this.$plotSpace = $("<div class='emperor-plot-wrapper'></div>");
 
     /**
+     * Div with the number of visible samples
+     * @type {node}
+     */
+    this.$plotBanner = $("<label>Loading ...</label>");
+    this.$plotBanner.css({'padding': '2px',
+                          'font-style': '9pt helvetica',
+                          'color': 'white',
+                          'border': '1px solid',
+                          'border-color': 'white',
+                          'position': 'absolute'});
+
+    // add the sample count to the plot space
+    this.$plotSpace.append(this.$plotBanner);
+
+    /**
      * Internal div where the plots live in (jQuery object).
      * @type {node}
      */
@@ -343,9 +358,44 @@ define([
         scope.renderer.setViewport(0, 0, scope.width, scope.height);
         scope.renderer.clear();
         sv.render();
+
+        // if there's a change for the scene view update the counts
+        scope.updatePlotBanner();
       }
     });
   };
+
+  /**
+   *
+   * Updates the plot banner based on the number of visible elements and the
+   * scene's background color.
+   *
+   */
+  EmperorController.prototype.updatePlotBanner = function() {
+    var color = this.sceneViews[0].scene.background.clone(), visible = 0,
+        total = 0;
+
+    // invert the color so it's visible regardless of the background
+    color.setRGB((Math.floor(color.r * 255) ^ 0xFF) / 255,
+                 (Math.floor(color.g * 255) ^ 0xFF) / 255,
+                 (Math.floor(color.b * 255) ^ 0xFF) / 255);
+    color = color.getStyle();
+
+    _.each(ec.decViews, function(decomposition) {
+      // computing this with every update requires traversin all elements,
+      // however it seems as the only reliable way to get this number right
+      // without depending on the view controllers (an anti-pattern)
+      visible += decomposition.getVisibleCount();
+      total += decomposition.count;
+    });
+
+    this.$plotBanner.css({'color': color, 'border-color': color});
+    this.$plotBanner.html(visible + '/' + total + ' visible');
+  }
+
+  EmperorController.prototype.getPlotBanner = function(text) {
+    return this.$plotBanner.text();
+  }
 
   /**
    *

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -30,11 +30,6 @@ function DecompositionView(decomp) {
    */
   this.count = decomp.length;
   /**
-   * Number of visible samples.
-   * @type {integer}
-   */
-  this.visibleCount = this.count;
-  /**
    * Top visible dimensions
    * @type {integer[]}
    * @default [0, 1, 2]
@@ -141,6 +136,22 @@ DecompositionView.prototype._initBaseView = function() {
   // this.decomp.applyAJ( ... ); Blame Jamie and Jose - baby steps buddy...
 
 };
+
+/**
+ *
+ * Get the number of visible elements
+ *
+ * @return {Number} The number of visible elements in this view.
+ *
+ */
+DecompositionView.prototype.getVisibleCount = function() {
+  var visible = 0;
+  visible = _.reduce(this.markers, function(acc, marker) {
+    return acc + (marker.visible + 0);
+  }, 0);
+
+  return visible;
+}
 
 /**
  *

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -151,7 +151,7 @@ DecompositionView.prototype.getVisibleCount = function() {
   }, 0);
 
   return visible;
-}
+};
 
 /**
  *

--- a/tests/javascript_tests/test_decomposition_view.js
+++ b/tests/javascript_tests/test_decomposition_view.js
@@ -64,7 +64,7 @@ requirejs([
 
       deepEqual(dv.decomp, exp, 'decomp set correctly');
       equal(dv.count, 2, 'count set correctly');
-      equal(dv.visibleCount, 2, 'visibleCount set correctly');
+      equal(dv.getVisibleCount(), 2, 'visibleCount set correctly');
       deepEqual(dv.visibleDimensions, [0, 1, 2],
           'visibleDimensions set correctly');
       deepEqual(dv.tubes, [], 'tubes set correctly');
@@ -94,6 +94,22 @@ requirejs([
          */
       // deepEqual(dv._genericSphere, undefined,
       //           "_genericSphere set correctly");
+    });
+
+    /**
+     *
+     * Test that getVisibleCount is correctly updated
+     *
+     */
+    test('Test getVisibleCount', function() {
+      var dv = new DecompositionView(this.decomp);
+      dv.markers[0].visible = false;
+      equal(dv.getVisibleCount(), 1);
+      dv.markers[1].visible = false;
+      equal(dv.getVisibleCount(), 0);
+      dv.markers[0].visible = true;
+      dv.markers[1].visible = true;
+      equal(dv.getVisibleCount(), 2);
     });
 
     /**


### PR DESCRIPTION
Just like in the previous version of emperor, though this time the banner's color is aware of the scene's background color to update accordingly.

For example:

![visible](https://user-images.githubusercontent.com/375307/30668070-795d3612-9e0e-11e7-9f3f-64a00c26c769.gif)
