### PR TITLE
BUG: Fixes a bug in the animations colors

### DIFF
--- a/emperor/support_files/js/animations-controller.js
+++ b/emperor/support_files/js/animations-controller.js
@@ -297,7 +297,6 @@ define([
 
     var grid = this.$canvas.height();
     grid -= this.$header.height() + this._$mediaContainer.height();
-    console.log('the grid height is: ' + grid);
     this.$gridDiv.height(grid);
 
     // the whole code is asynchronous, so there may be situations where
@@ -387,7 +386,7 @@ define([
    * @private
    */
   AnimationsController.prototype._gradientChanged = function(evt, params) {
-    if (this.getGradientCategory() !== '' && !this.enabled &&
+    if (this.getGradientCategory() !== '' &&
         this.getTrajectoryCategory() !== '') {
       this.setEnabled(true);
       this._updateGrid();
@@ -405,7 +404,7 @@ define([
    * @private
    */
   AnimationsController.prototype._trajectoryChanged = function(evt, params) {
-    if (this.getGradientCategory() !== '' && !this.enabled &&
+    if (this.getGradientCategory() !== '' &&
         this.getTrajectoryCategory() !== '') {
       this.setEnabled(true);
       this._updateGrid();

--- a/tests/javascript_tests/test_animations_controller.js
+++ b/tests/javascript_tests/test_animations_controller.js
@@ -137,12 +137,14 @@ requirejs([
     test('Test trajectory category setter/getter', function(assert) {
       this.controller.setTrajectoryCategory('DOB');
       equal(this.controller.getTrajectoryCategory(), 'DOB');
+      deepEqual(this.controller.getColors(), {});
 
       this.controller.setGradientCategory('Does not exist either');
       equal(this.controller.getGradientCategory(), '');
 
       this.controller.setTrajectoryCategory('Treatment');
       equal(this.controller.getTrajectoryCategory(), 'Treatment');
+      deepEqual(this.controller.getColors(), {});
     });
 
     test('Test trajectory and category methods together', function(assert) {
@@ -152,12 +154,15 @@ requirejs([
 
       this.controller.setTrajectoryCategory('Treatment');
       equal(this.controller.enabled, false);
+      deepEqual(this.controller.getColors(), {});
 
       this.controller.setGradientCategory('DOB');
       equal(this.controller.enabled, true);
+      deepEqual(this.controller.getColors(), {'Fast': '#ff0000'});
 
       this.controller.setTrajectoryCategory('');
       equal(this.controller.enabled, false);
+      deepEqual(this.controller.getColors(), {});
     });
 
     test('Test colors setter/getter', function(assert) {


### PR DESCRIPTION
The grid displaying the colors for the traces was not updated after the
first change to the trajectory category. This has been fixed and I've
added a few missing tests.