### PR TITLE
ENH: Add exceptions and tests for missing samples

### DIFF
--- a/emperor/core.py
+++ b/emperor/core.py
@@ -248,9 +248,10 @@ class Emperor(object):
         return display(HTML(str(self)))
 
     def _validate_metadata(self, ignore_missing_samples):
-        difference = set(self.ordination.samples.index) - set(self.mf.index)
+        ordination_samples = set(self.ordination.samples.index)
+        difference = ordination_samples - set(self.mf.index)
 
-        if len(difference) == len(self.ordination.samples):
+        if difference == ordination_samples:
             raise ValueError('None the sample identifiers match between the '
                              'metadata and the coordinates. Verify that you '
                              'are using metadata and coordinates corresponding'
@@ -261,7 +262,7 @@ class Emperor(object):
                            "file. Override this error by using the "
                            "`ignore_missing_samples` argument. Offending "
                            "samples: %s"
-                           % ', '.join([str(i) for i in difference]))
+                           % ', '.join(sorted([str(i) for i in difference])))
         elif difference and ignore_missing_samples:
             # pad the missing samples
             data = np.full((len(difference), self.mf.shape[1]),

--- a/emperor/core.py
+++ b/emperor/core.py
@@ -265,7 +265,7 @@ class Emperor(object):
         elif difference and ignore_missing_samples:
             # pad the missing samples
             data = np.full((len(difference), self.mf.shape[1]),
-                           'This sample has no metadata')
+                           'This sample has no metadata', dtype='<U27')
             pad = pd.DataFrame(index=difference, columns=self.mf.columns,
                                data=data)
             self.mf = pd.concat([self.mf, pad])

--- a/emperor/core.py
+++ b/emperor/core.py
@@ -252,8 +252,8 @@ class Emperor(object):
         difference = ordination_samples - set(self.mf.index)
 
         if difference == ordination_samples:
-            raise ValueError('None the sample identifiers match between the '
-                             'metadata and the coordinates. Verify that you '
+            raise ValueError('None of the sample identifiers match between the'
+                             ' metadata and the coordinates. Verify that you '
                              'are using metadata and coordinates corresponding'
                              ' to the same dataset.')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -157,8 +157,9 @@ class TopLevelTests(TestCase):
 
         expected.loc['PC.634'] = ['This sample has no metadata'] * 3
 
-        pd.testing.assert_frame_equal(expected.sort_index(),
-                                      emp.mf.sort_index(), check_names=False)
+        pd.util.testing.assert_frame_equal(expected.sort_index(),
+                                           emp.mf.sort_index(),
+                                           check_names=False)
 
     def test_no_overlap(self):
         self.mf.index = self.mf.index + '.not'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -142,11 +142,11 @@ class TopLevelTests(TestCase):
 
     def test_initial_unbalanced(self):
         self.mf.drop(['PC.354'], inplace=True)
-        with self.assertRaisesRegex(KeyError, "There are samples not "
-                                    "included in the mapping file. Override "
-                                    "this error by using the "
-                                    "`ignore_missing_samples` argument. "
-                                    "Offending samples: PC.354"):
+        with self.assertRaisesRegexp(KeyError, "There are samples not "
+                                     "included in the mapping file. Override "
+                                     "this error by using the "
+                                     "`ignore_missing_samples` argument. "
+                                     "Offending samples: PC.354"):
             Emperor(self.ord_res, self.mf, remote=self.url)
 
     def test_initial_unbalanced_ignore(self):
@@ -163,11 +163,11 @@ class TopLevelTests(TestCase):
     def test_no_overlap(self):
         self.mf.index = self.mf.index + '.not'
 
-        with self.assertRaisesRegex(ValueError, 'None the sample identifiers '
-                                    'match between the metadata and the '
-                                    'coordinates. Verify that you are using '
-                                    'metadata and coordinates corresponding to'
-                                    ' the same dataset.'):
+        with self.assertRaisesRegexp(ValueError, 'None the sample identifiers '
+                                     'match between the metadata and the '
+                                     'coordinates. Verify that you are using '
+                                     'metadata and coordinates corresponding '
+                                     'to the same dataset.'):
             Emperor(self.ord_res, self.mf, remote=self.url)
 
     def test_get_template(self):


### PR DESCRIPTION
Two cases are now explicitly checked for:

1) None of the samples in the ordination are part of the metadata.

2) Some samples in the coordinates matrix are not part of the metadata.
In this case the error can be overridden with the ingore_missing_samples
argument.