### PR TITLE
ENH:Download colormap instead of discrete legend

### DIFF
--- a/emperor/support_files/js/color-view-controller.js
+++ b/emperor/support_files/js/color-view-controller.js
@@ -266,7 +266,7 @@ define([
   ColorViewController.prototype.isColoringContinuous = function() {
     // the bodygrid can have at most one element (NA values)
     return this.$scaled.is(':checked') && this.bodyGrid.getData().length <= 1;
-  }
+  };
 
   /**
    *

--- a/emperor/support_files/js/color-view-controller.js
+++ b/emperor/support_files/js/color-view-controller.js
@@ -51,7 +51,7 @@ define([
      *  jQuery object holding the SVG colorbar
      */
     this.$colorScale = $("<svg width='90%' height='100%' " +
-                         "'style='display:block;margin:auto;'></svg>");
+                         "style='display:block;margin:auto;'></svg>");
     this.$scaleDiv.append(this.$colorScale);
     this.$scaleDiv.hide();
     /**
@@ -255,6 +255,18 @@ define([
       view.needsUpdate = true;
     });
   };
+
+  /**
+   * Method that returns whether or not the coloring is continuous and the
+   * values have been scaled.
+   *
+   * @return {Boolean} True if the coloring is continuous and the data is
+   * scaled, false otherwise.
+   */
+  ColorViewController.prototype.isColoringContinuous = function() {
+    // the bodygrid can have at most one element (NA values)
+    return this.$scaled.is(':checked') && this.bodyGrid.getData().length <= 1;
+  }
 
   /**
    *

--- a/tests/javascript_tests/test_color_view_controller.js
+++ b/tests/javascript_tests/test_color_view_controller.js
@@ -108,6 +108,29 @@ requirejs([
       equal(controller.$scaled.is(':disabled'), true);
     });
 
+    test('Is coloring continuous', function() {
+      var container = $('<div id="no-exist" style="height:11px; ' +
+                        'width:12px"></div>');
+
+      var controller = new ColorViewController(
+        container, this.sharedDecompositionViewDict);
+      equal(controller.title, 'Color');
+
+      equal(controller.isColoringContinuous(), false);
+
+      controller.setMetadataField('Mixed');
+      controller.$colormapSelect.val('Viridis').trigger('chosen:updated');
+      controller.$scaled.prop('checked', true).trigger('change');
+
+      equal(controller.isColoringContinuous(), true);
+
+      controller.setMetadataField('DOB');
+      controller.$colormapSelect.val('Viridis').trigger('chosen:updated');
+      controller.$scaled.prop('checked', true).trigger('change');
+
+      equal(controller.isColoringContinuous(), true);
+    });
+
     test('Test _nonNumericPlottables', function() {
       var container = $('<div id="no-exist" style="height:11px; ' +
                         'width:12px"></div>');
@@ -583,6 +606,7 @@ requirejs([
       equal(controller.$select.val(), 'Mixed');
       equal(controller.$colormapSelect.val(), 'Viridis');
       equal(controller.$scaled.is(':checked'), true);
+      equal(controller.isColoringContinuous(), true);
     });
 
     test('Testing toJSON (null)', function() {
@@ -617,6 +641,7 @@ requirejs([
       equal(controller.$select.val(), null);
       equal(controller.$colormapSelect.val(), 'discrete-coloring-qiime');
       equal(controller.$scaled.is(':checked'), false);
+      equal(controller.isColoringContinuous(), false);
     });
 
     asyncTest('Test setEnabled', function() {


### PR DESCRIPTION
Previously when a continuous colormap was set and the user downloaded
the SVG image, Emperor would produce a categorical list of the values,
this PR changes this so that a colormap is produced instead.

Fixes #336