### PR TITLE
BUG: Sort unique metadata categories

### DIFF
--- a/emperor/support_files/js/model.js
+++ b/emperor/support_files/js/model.js
@@ -4,6 +4,7 @@ define([
     'util'
 ],
 function($, _, util) {
+  var naturalSort = util.naturalSort;
   /**
    *
    * @class Plottable
@@ -338,7 +339,8 @@ function($, _, util) {
 
     var md_idx = this._getMetadataIndex(category);
     var res = _.filter(this.plottable, function(pl) {
-      return pl.metadata[md_idx] === value; });
+      return pl.metadata[md_idx] === value;
+    });
 
     if (res.length === 0) {
       throw new Error('The value ' + value +
@@ -354,13 +356,16 @@ function($, _, util) {
    * @param {string} category A string with the metadata header.
    *
    * @return {string[]} An array of the available values for the given metadata
-   * header.
+   * header sorted first alphabetically and then numerically.
    *
    */
   DecompositionModel.prototype.getUniqueValuesByCategory = function(category) {
     var md_idx = this._getMetadataIndex(category);
-    return _.uniq(
-      _.map(this.plottable, function(pl) {return pl.metadata[md_idx];}));
+    var values = _.map(this.plottable, function(pl) {
+      return pl.metadata[md_idx];
+    });
+
+    return naturalSort(_.uniq(values));
   };
 
   /**

--- a/tests/javascript_tests/test_decomposition_model.js
+++ b/tests/javascript_tests/test_decomposition_model.js
@@ -619,6 +619,29 @@ requirejs([
     /**
      *
      * Tests if a unique set of metadata category values can be obtained from a
+     * metadata category of mixed types.
+     *
+     */
+    test('Test getUniqueValuesByCategory mixed types', function() {
+      var mixedValues = ['b', '-1', '3', '0', '-5', '100', 'b', 'a', 'A'];
+
+      this.metadata = _.map(this.metadata, function(row, index) {
+        row.push(mixedValues[index]);
+        return row;
+      });
+      this.md_headers.push('Mixed');
+
+      var dm = new DecompositionModel(this.data, this.md_headers,
+                                      this.metadata);
+      var obs = dm.getUniqueValuesByCategory('Mixed');
+      var exp = ['a', 'A', 'b', '-5', '-1', '0', '3', '100'];
+
+      deepEqual(obs, exp, 'Unique metadata values retrieved successfully');
+    });
+
+    /**
+     *
+     * Tests if a unique set of metadata category values can be obtained from a
      * metadata category
      *
      */


### PR DESCRIPTION
Fixes a problem where metadata categories would appear to be ordered
randomly. Unique values are now sorted first alphabetically and then
numerically, mimicking the behaviour of the previous version of Emperor.

Fixes #618