### PR TITLE
ENH: Add download scree plot button

### DIFF
--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -4,8 +4,10 @@ define([
     'view',
     'viewcontroller',
     'd3',
-    'contextmenu'
-], function($, _, DecompositionView, ViewControllers, d3, contextmenu) {
+    'contextmenu',
+    'filesaver'
+], function($, _, DecompositionView, ViewControllers, d3, contextmenu,
+            FileSaver) {
   var EmperorViewController = ViewControllers.EmperorViewController;
 
   /**
@@ -87,7 +89,6 @@ define([
                                    'vertical-align': 'middle',
                                    'overflow': 'hidden'});
 
-
     this.$body.append(this.$_screePlotContainer);
 
     /**
@@ -101,7 +102,7 @@ define([
       'position': 'absolute',
       'z-index': '3',
       'top': '10px',
-      'right': '5px',
+      'right': '5px'
     }).button({text: false,
                              icons: {primary: ' ui-icon-circle-arrow-s'}
     }).attr('title', 'Download Scree Plot');
@@ -411,7 +412,7 @@ define([
 
       blob = new Blob([svg], {type: 'image/svg+xml'});
       saveAs(blob, 'emperor-scree-plot.svg');
-  }
+  };
 
   /**
    * Callback to reposition an axis

--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -87,7 +87,25 @@ define([
                                    'vertical-align': 'middle',
                                    'overflow': 'hidden'});
 
+
     this.$body.append(this.$_screePlotContainer);
+
+    /**
+     * @type {Node}
+     * jQuery object containing the download scree plot button
+     *
+     * See also the private method _downloadScreePlot
+     */
+    this.$saveButton = $('<button>&nbsp;</save>');
+    this.$saveButton.css({
+      'position': 'absolute',
+      'z-index': '3',
+      'top': '10px',
+      'right': '5px',
+    }).button({text: false,
+                             icons: {primary: ' ui-icon-circle-arrow-s'}
+    }).attr('title', 'Download Scree Plot');
+    this.$_screePlotContainer.append(this.$saveButton);
 
     /**
      * @type {Node}
@@ -375,7 +393,25 @@ define([
       .style('shape-rendering', 'crispEdges');
 
     this.screePlot = svg;
+
+    this.$saveButton.on('click', function() {
+      scope._downloadScreePlot();
+    });
   };
+
+  /**
+   *
+   * Helper method to download the scree plot as an SVG file.
+   *
+   */
+  AxesController.prototype._downloadScreePlot = function() {
+      // converting svgRenderer to string: http://stackoverflow.com/a/17415624
+      var XMLS = new XMLSerializer();
+      var svg = XMLS.serializeToString(this.screePlot.node().ownerSVGElement);
+
+      blob = new Blob([svg], {type: 'image/svg+xml'});
+      saveAs(blob, 'emperor-scree-plot.svg');
+  }
 
   /**
    * Callback to reposition an axis

--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -692,13 +692,20 @@ define([
       saveAs(blob, 'emperor-image.svg');
 
       // generating legend
-      var names = [], colors = [];
-      _.each(this.controllers.color.bodyGrid.getData(), function(element) {
-        names.push(element.category);
-        colors.push(element.value);
-      });
-      blob = new Blob([Draw.formatSVGLegend(names, colors)],
-                      {type: 'image/svg+xml'});
+      var names = [], colors = [], legend;
+
+      if (this.controllers.color.isColoringContinuous()) {
+        legend = XMLS.serializeToString(this.controllers.color.$colorScale[0]);
+      }
+      else {
+        _.each(this.controllers.color.bodyGrid.getData(), function(element) {
+          names.push(element.category);
+          colors.push(element.value);
+        });
+
+        legend = Draw.formatSVGLegend(names, colors);
+      }
+      blob = new Blob([legend], {type: 'image/svg+xml'});
       saveAs(blob, 'emperor-image-labels.svg');
     } else {
       console.error('Screenshot type not implemented');


### PR DESCRIPTION
This PR adds a button to download an SVG file of the scree plot.

This also includes a few lines that were missing from #638 (I accidentally left them out 😱 ... see controller.js).

![scree-plot](https://user-images.githubusercontent.com/375307/36329939-ca77e0d2-1335-11e8-9171-b68a50d7083c.gif)


Fixes #599