### PR TITLE
ENH: Increase text size

### DIFF
--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -122,23 +122,31 @@ define(['underscore', 'three'], function(_, THREE) {
    * @function makeLabel
    **/
   function makeLabel(position, text, color, factor) {
-    var canvas = document.createElement('canvas');
-    var size = 1024;
-
     factor = (factor === undefined ? 1 : factor);
 
-    canvas.width = size;
-    canvas.height = size;
-    var context = canvas.getContext('2d');
+    var fontSize = 30 * factor, canvas, context, measure;
+
+    canvas = document.createElement('canvas');
+    context = canvas.getContext('2d');
+
+    // set the font size so we can measure the width
+    context.font = fontSize + 'px Arial';
+    measure = context.measureText(text);
+
+    // make the dimensions squared and a power of 2 (for use in THREE.js)
+    canvas.width = Math.pow(2, Math.ceil(Math.log2(measure.width)));
+    canvas.height = canvas.width;
+
+    // after changing the canvas' size we need to reset the font attributes
+    context.textAlign = 'center';
+    context.font = fontSize + 'px Arial';
     if (_.isNumber(color)) {
       context.fillStyle = '#' + color.toString(16);
     }
     else {
       context.fillStyle = color;
     }
-    context.textAlign = 'center';
-    context.font = (30 * factor) + 'px Arial';
-    context.fillText(text, size / 2, size / 2);
+    context.fillText(text, canvas.width / 2, canvas.height / 2);
 
     var amap = new THREE.Texture(canvas);
     amap.needsUpdate = true;

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -112,19 +112,17 @@ define(['underscore', 'three'], function(_, THREE) {
    * [here]{@link http://stackoverflow.com/a/14106703/379593}
    *
    * @param {float[]} position The x, y, and z location of the label.
-   * @param {string} text with the text to be shown on screen.
+   * @param {string} text The text to be shown on screen.
    * @param {integer|string} Color Hexadecimal base that represents the color
    * of the text.
-   * @param {float} [1] factor An optional scaling factor to determine the size
-   * of the labels.
    *
    * @return {THREE.Sprite} Object with the text displaying in it.
    * @function makeLabel
    **/
-  function makeLabel(position, text, color, factor) {
-    factor = (factor === undefined ? 1 : factor);
+  function makeLabel(position, text, color) {
 
-    var fontSize = 30 * factor, canvas, context, measure;
+    // the font size determines the resolution relative to the sprite object
+    var fontSize = 30, canvas, context, measure;
 
     canvas = document.createElement('canvas');
     context = canvas.getContext('2d');
@@ -135,10 +133,11 @@ define(['underscore', 'three'], function(_, THREE) {
 
     // make the dimensions squared and a power of 2 (for use in THREE.js)
     canvas.width = Math.pow(2, Math.ceil(Math.log2(measure.width)));
-    canvas.height = canvas.width;
+    canvas.height = Math.pow(2, Math.ceil(Math.log2(fontSize)));
 
     // after changing the canvas' size we need to reset the font attributes
     context.textAlign = 'center';
+    context.textBaseline = 'middle';
     context.font = fontSize + 'px Arial';
     if (_.isNumber(color)) {
       context.fillStyle = '#' + color.toString(16);
@@ -159,7 +158,7 @@ define(['underscore', 'three'], function(_, THREE) {
 
     var sp = new THREE.Sprite(mat);
     sp.position.set(position[0], position[1], position[2]);
-    sp.scale.set(0.75, 0.75, 0.75);
+    sp.scale.set(1 * 0.5, (canvas.height / canvas.width) * 0.5, 1);
 
     // add an extra attribute so we can render this properly when we use
     // SVGRenderer

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -159,6 +159,7 @@ define(['underscore', 'three'], function(_, THREE) {
 
     var sp = new THREE.Sprite(mat);
     sp.position.set(position[0], position[1], position[2]);
+    sp.scale.set(0.75, 0.75, 0.75);
 
     // add an extra attribute so we can render this properly when we use
     // SVGRenderer

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -477,15 +477,13 @@ define([
    *
    */
   ScenePlotView3D.prototype.drawAxesLabelsWithColor = function(color) {
-    var scope = this, axisLabel, decomp, firstKey, text, factor;
+    var scope = this, axisLabel, decomp, firstKey, text;
 
     // the labels are only removed if the color is null
     this.removeAxesLabels();
     if (color === null) {
       return;
     }
-
-    factor = (this.dimensionRanges.max[0] - this.dimensionRanges.min[0]) * 0.9;
 
     // get the first decomposition object, it doesn't really mater which one
     // we look at though, as all of them should have the same percentage
@@ -508,7 +506,7 @@ define([
         text += ' (' + decomp.percExpl[index].toPrecision(4) + ' %)';
       }
 
-      axisLabel = makeLabel(end, text, color, factor);
+      axisLabel = makeLabel(end, text, color);
       axisLabel.name = scope._axisLabelPrefix + index;
 
       scope.scene.add(axisLabel);

--- a/tests/javascript_tests/runner.js
+++ b/tests/javascript_tests/runner.js
@@ -45,7 +45,7 @@
         page.evaluate(addLogging);
 
         // https://stackoverflow.com/a/29506120/379593
-        page.evaluate(function(){
+        page.evaluate(function() {
             Math.log2 = Math.log2 || function(x) {
                 return Math.log(x) / Math.LOG2E;
             };

--- a/tests/javascript_tests/runner.js
+++ b/tests/javascript_tests/runner.js
@@ -43,6 +43,13 @@
 
     page.onInitialized = function() {
         page.evaluate(addLogging);
+
+        // https://stackoverflow.com/a/29506120/379593
+        page.evaluate(function(){
+            Math.log2 = Math.log2 || function(x) {
+                return Math.log(x) / Math.LOG2E;
+            };
+        });
     };
 
     page.onCallback = function(message) {


### PR DESCRIPTION
This patch increases the labels' size by dynamically calculating the
dimensions of the canvas depending on the font and the width of the
text.

Fixes #598

As a comparison:

# Before

![screen shot 2018-02-22 at 12 55 41 pm](https://user-images.githubusercontent.com/375307/36563897-644af93a-17d0-11e8-98c5-8694edb92688.png)


# After

![screen shot 2018-02-22 at 12 55 44 pm](https://user-images.githubusercontent.com/375307/36563901-6794362e-17d0-11e8-87f3-c5a7b84634a6.png)
