### PR TITLE
ENH: Warn users when hiding samples from a plot

### DIFF
--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -418,7 +418,7 @@ define([
    */
   EmperorController.prototype.updatePlotBanner = function() {
     var color = this.sceneViews[0].scene.background.clone(), visible = 0,
-        total = 0;
+        total = 0, message = '';
 
     // invert the color so it's visible regardless of the background
     color.setRGB((Math.floor(color.r * 255) ^ 0xFF) / 255,
@@ -435,7 +435,13 @@ define([
     });
 
     this.$plotBanner.css({'color': color, 'border-color': color});
-    this.$plotBanner.html(visible + '/' + total + ' visible');
+
+    if (visible !== total) {
+      message = ' <br> WARNING: hiding samples in an ordination can be ' +
+                'misleading';
+    }
+
+    this.$plotBanner.html(visible + '/' + total + ' visible' + message);
   };
 
   EmperorController.prototype.getPlotBanner = function(text) {


### PR DESCRIPTION
This patch adds a message (in the sample counter) stating that hiding
samples in an ordination can be misleading.

Fixes #589 

Example animated gif:

![emperor](https://user-images.githubusercontent.com/375307/36567151-79a64712-17da-11e8-8bcf-935a6b61e339.gif)
