### PR TITLE
BUG: Fix problem with double-click resize

### DIFF
--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -210,7 +210,9 @@ define([
             scope.resize(scope.width, scope.height);
           }, 50);
         }
-      }).dblclick(function() {
+      });
+
+      scope.$plotMenu.find('.ui-resizable-handle').dblclick(function() {
         var percent = (scope.$plotSpace.width() / scope.width) * 100;
 
         // allow for a bit of leeway


### PR DESCRIPTION
Resizing the menu would erroneously be triggered by double-clicking the
menu, whereas it should only be triggered when double-clicking the
resize handle.

This had previously been reported by @wasade and a few others.