### PR TITLE
ENH: Add button to show context menu

### DIFF
--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -97,14 +97,14 @@ define([
      *
      * See also the private method _downloadScreePlot
      */
-    this.$saveButton = $('<button>&nbsp;</save>');
+    this.$saveButton = $('<button>&nbsp;</button>');
     this.$saveButton.css({
       'position': 'absolute',
       'z-index': '3',
       'top': '10px',
       'right': '5px'
-    }).button({text: false,
-                             icons: {primary: ' ui-icon-circle-arrow-s'}
+    }).button({
+      text: false, icons: {primary: ' ui-icon-circle-arrow-s'}
     }).attr('title', 'Download Scree Plot');
     this.$_screePlotContainer.append(this.$saveButton);
 

--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -183,10 +183,34 @@ define([
      */
     this.decViews = {'scatter': new DecompositionView(this.dm)};
 
+    /**
+     * @type {Node}
+     * jQuery object To show the context menu (as an alternative to
+     * right-clicking on the plot).
+     *
+     * The context menu that this button shows is created in the _buildUI
+     * method.
+     */
+    this.$optionsButton = $('<button name="options-button">&nbsp;</button>');
+    this.$optionsButton.css({
+      'position': 'absolute',
+      'z-index': '3',
+      'top': '5px',
+      'right': '5px'
+    }).attr('title', 'More Options').on('click', function(event) {
+      // add offset to avoid overlapping the button with the menu
+      scope.$plotSpace.contextMenu({x: event.pageX, y: event.pageY + 5});
+    });
+    this.$plotSpace.append(this.$optionsButton);
+
     // default decomposition view uses the full window
     this.addSceneView();
 
     $(function() {
+      // setup the jquery properties of the button
+      scope.$optionsButton.button({text: false,
+                                   icons: {primary: ' ui-icon-gear'}});
+
       scope._buildUI();
       // Hide the loading splashscreen
       scope.$divId.find('.loading').hide();


### PR DESCRIPTION
This should improve the discoverability of the context menu, HT to @wasade for pointing this out. Right clicking continues to work, just in case.

Example as a standalone plot:
![standalone](https://user-images.githubusercontent.com/375307/37542950-2c61abf0-291d-11e8-855f-d5b414223b74.gif)


Example as a plot in the Jupyter notebook:
![jupyter](https://user-images.githubusercontent.com/375307/37542945-28cbc3b8-291d-11e8-91b6-eac4b58a5dc2.gif)


While putting this together, I noticed a couple of oddities in styling of the axes-controller.js file, hence those unrelated changes.