### PR TITLE
BUG: Prevent input propagation in the notebook 📓

### DIFF
--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -65,12 +65,26 @@ define([
                   scope.colorChanged($(this).attr('name'), color);
                 }
     };
-    // spectrumify all the elements in the body that have a name ending in
-    // color
-    this.$body.find('[name="axes-color"]').spectrum(opts);
+
+    var stop = function(event) {
+      event.stopPropagation();
+    };
+
+    // spectrumify the axes and background color selectors
+    // Don't propagate the keydown and keypress events so that inputing a color
+    // doesn't interfere with the shortcuts of the Jupyter Notebook
+    this.$body.find('[name="axes-color"]')
+      .spectrum(opts)
+      .spectrum('container')
+      .find('.sp-input')
+      .on('keydown keypress', stop);
     opts.color = 'black';
     opts.allowEmpty = false;
-    this.$body.find('[name="background-color"]').spectrum(opts);
+    this.$body.find('[name="background-color"]')
+      .spectrum(opts)
+      .spectrum('container')
+      .find('.sp-input')
+      .on('keydown keypress', stop);
 
     /**
      * @type {Node}

--- a/emperor/support_files/js/color-editor.js
+++ b/emperor/support_files/js/color-editor.js
@@ -65,6 +65,15 @@ function($, _, DecompositionView, ViewControllers, spectrum) {
           args.grid.resetActiveCell();
         }
       });
+
+      // Don't propagate the keydown and keypress events so that inputing a
+      // color doesn't interfere with the shortcuts of the Jupyter Notebook
+      $input
+        .spectrum('container')
+        .find('.sp-input')
+        .on('keydown keypress', function(e) {
+          e.stopPropagation();
+        });
     };
 
     this.destroy = function() {


### PR DESCRIPTION
The text inputs in the color picker propagated the keypress and keydown
events all the way down to the notebook. In the case where the inputs
conflicted with a shortcut in the notebook, the shortcut itself would be
triggered.

This has been fixed by preventing the propagation of events in all the
color pickers.

Thanks to @JWDebelius for reporting this bug. 👍 