### PR TITLE
BUG:Add missing attribute types in settings setter

### DIFF
--- a/emperor/core.py
+++ b/emperor/core.py
@@ -1191,6 +1191,13 @@ class Emperor(object):
             elif key == 'color':
                 self.color_by(val['category'], val['data'], val['colormap'],
                               val['continuous'])
+            elif key == 'opacity':
+                self.opacity_by(val['category'], val['data'],
+                                float(val['globalScale']), val['scaleVal'])
+            elif key == 'animations':
+                self.animations_by(val['gradientCategory'],
+                                   val['trajectoryCategory'], val['colors'],
+                                   val['speed'], val['radius'])
             else:
                 raise KeyError('Unrecognized settings key: %s' % key)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1219,7 +1219,18 @@ class EmperorSettingsTests(TestCase):
                                                 '20070314': True,
                                                 '20071112': False,
                                                 '20071210': True,
-                                                '20080116': False}}
+                                                '20080116': False}},
+                        'opacity': {"category": 'DOB',
+                                    "data": {},
+                                    "globalScale": "1.0",
+                                    "scaleVal": False},
+                        'animations': {"gradientCategory": 'DOB',
+                                       "trajectoryCategory": 'Treatment',
+                                       "speed": 1,
+                                       "radius": 1,
+                                       "colors": {"Fast": "red",
+                                                  "Control": "blue"}
+                                       }
                         }
 
         emp = Emperor(self.ord_res, self.mf, remote=False)


### PR DESCRIPTION
The setting setter was not taking into consideration the opacity and the
animations types.

Fixes #650