### PR TITLE
BUG: Hide edges when hiding visible samples

### DIFF
--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -174,6 +174,44 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
 
   /**
    *
+   * @class EmperorLineSegments
+   *
+   * Subclass of THREE.LineSegments to make vertex modifications easier.
+   *
+   * @return {EmperorLineSegments}
+   * @extends THREE.LineSegments
+   */
+  function EmperorLineSegments(geometry, material) {
+    THREE.LineSegments.call(this, geometry, material);
+
+    return this;
+  }
+  EmperorLineSegments.prototype = Object.create(THREE.LineSegments.prototype);
+  EmperorLineSegments.prototype.constructor = THREE.LineSegments;
+
+  /**
+   *
+   * Set the start and end points for a line in the collection.
+   *
+   * @param {Integer} i The index of the line;
+   * @param {Float[]} start An array of the starting point of the line ([x, y,
+   * z]).
+   * @param {Float[]} start An array of the ending point of the line ([x, y,
+   * z]).
+   */
+  EmperorLineSegments.prototype.setLineAtIndex = function(i, start, end) {
+    var vertices = this.geometry.attributes.position.array;
+
+    vertices[(i * 6)] = start[0];
+    vertices[(i * 6) + 1] = start[1];
+    vertices[(i * 6) + 2] = start[2];
+    vertices[(i * 6) + 3] = end[0];
+    vertices[(i * 6) + 4] = end[1];
+    vertices[(i * 6) + 5] = end[2];
+  };
+
+  /**
+   *
    * Create a collection of disconnected lines.
    *
    * This function is specially useful when creating a lot of lines as it uses
@@ -185,7 +223,7 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
    * @param {integer} color Hexadecimal base that specifies the color of the
    * line.
    *
-   * @return {THREE.LineSegments}
+   * @return {EmperorLineSegments}
    * @function makeLineCollection
    *
    */
@@ -210,7 +248,7 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
     geometry.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
 
-    return new THREE.LineSegments(geometry, material);
+    return new EmperorLineSegments(geometry, material);
   }
 
   /**

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -258,15 +258,35 @@ DecompositionView.prototype.updatePositions = function() {
   // edges are made using THREE.LineSegments and a buffer geometry so updating
   // the position takes a bit more work but these objects will render faster
   if (this.decomp.edges.length) {
-    var left, center, right, u, v, positionsLeft, positionsRight, j = 0;
-    positionsLeft = this.lines.left.geometry.attributes.position.array;
-    positionsRight = this.lines.right.geometry.attributes.position.array;
+    this._redrawEdges();
+  }
+  this.needsUpdate = true;
+};
 
-    this.decomp.edges.forEach(function(edge) {
-      u = edge[0];
-      v = edge[1];
 
-      // x, y and z are the visible dimensions (see above)
+/**
+ *
+ * Internal method to draw edges for plottables
+ *
+ * @param {Plottable[]} plottables An array of plottables for which the edges
+ * should be redrawn. If this object is not supplied, all the edges are drawn.
+ */
+DecompositionView.prototype._redrawEdges = function(plottables) {
+  var u, v, j = 0, left = [], right = [], positionsLeft, positionsRight;
+  var x = this.visibleDimensions[0], y = this.visibleDimensions[1],
+      z = this.visibleDimensions[2], scope = this,
+      is2D = (z === null), drawAll = (plottables === undefined);
+
+  positionsLeft = this.lines.left.geometry.attributes.position.array;
+  positionsRight = this.lines.right.geometry.attributes.position.array;
+
+  this.decomp.edges.forEach(function(edge) {
+    u = edge[0];
+    v = edge[1];
+
+    if (drawAll ||
+        (plottables.indexOf(u) !== -1 || plottables.indexOf(v) !== -1)) {
+
       center = [(u.coordinates[x] + v.coordinates[x]) / 2,
                 (u.coordinates[y] + v.coordinates[y]) / 2,
                 (u.coordinates[z] + v.coordinates[z]) / 2];
@@ -291,14 +311,15 @@ DecompositionView.prototype.updatePositions = function() {
       positionsRight[(j * 6) + 4] = center[1] * scope.axesOrientation[1];
       positionsRight[(j * 6) + 5] = ((is2D ? 0 : center[2]) *
                                      scope.axesOrientation[2]);
+    }
 
-      j++;
-    });
+    j++;
+  });
 
-    // otherwise the geometry will remain unchanged
-    this.lines.left.geometry.attributes.position.needsUpdate = true;
-    this.lines.right.geometry.attributes.position.needsUpdate = true;
-  }
+  // otherwise the geometry will remain unchanged
+  this.lines.left.geometry.attributes.position.needsUpdate = true;
+  this.lines.right.geometry.attributes.position.needsUpdate = true;
+
   this.needsUpdate = true;
 };
 
@@ -412,6 +433,71 @@ DecompositionView.prototype.setCategory = function(attributes,
   this.needsUpdate = true;
 
   return dataView;
+};
+
+/**
+ *
+ * Hide edges where plottables are present.
+ *
+ * @param {Plottable[]} plottables An array of plottables for which the edges
+ * should be hidden. If this object is not supplied, all the edges are hidden.
+ */
+DecompositionView.prototype.hideEdgesForPlottables = function(plottables) {
+  // no edges to hide
+  if (this.decomp.edges.length === 0) {
+    return;
+  }
+
+  var u, v, j = 0, positionsLeft, positionsRight, hideAll;
+
+  positionsLeft = this.lines.left.geometry.attributes.position.array;
+  positionsRight = this.lines.right.geometry.attributes.position.array;
+
+  hideAll = plottables === undefined;
+
+  this.decomp.edges.forEach(function(edge) {
+    u = edge[0];
+    v = edge[1];
+
+    if (hideAll ||
+        (plottables.indexOf(u) !== -1 || plottables.indexOf(v) !== -1)) {
+      positionsLeft[(j * 6)] = 0;
+      positionsLeft[(j * 6) + 1] = 0;
+      positionsLeft[(j * 6) + 2] = 0;
+      positionsLeft[(j * 6) + 3] = 0;
+      positionsLeft[(j * 6) + 4] = 0;
+      positionsLeft[(j * 6) + 5] = 0;
+
+      positionsRight[(j * 6)] = 0;
+      positionsRight[(j * 6) + 1] = 0;
+      positionsRight[(j * 6) + 2] = 0;
+      positionsRight[(j * 6) + 3] = 0;
+      positionsRight[(j * 6) + 4] = 0;
+      positionsRight[(j * 6) + 5] = 0;
+    }
+
+    j++;
+  });
+
+  // otherwise the geometry will remain unchanged
+  this.lines.left.geometry.attributes.position.needsUpdate = true;
+  this.lines.right.geometry.attributes.position.needsUpdate = true;
+};
+
+/**
+ *
+ * Hide edges where plottables are present.
+ *
+ * @param {Plottable[]} plottables An array of plottables for which the edges
+ * should be hidden. If this object is not supplied, all the edges are hidden.
+ */
+DecompositionView.prototype.showEdgesForPlottables = function(plottables) {
+  // no edges to show
+  if (this.decomp.edges.length === 0) {
+    return;
+  }
+
+  this._redrawEdges(plottables);
 };
 
   return DecompositionView;

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -272,13 +272,10 @@ DecompositionView.prototype.updatePositions = function() {
  * should be redrawn. If this object is not supplied, all the edges are drawn.
  */
 DecompositionView.prototype._redrawEdges = function(plottables) {
-  var u, v, j = 0, left = [], right = [], positionsLeft, positionsRight;
+  var u, v, j = 0, left = [], right = [];
   var x = this.visibleDimensions[0], y = this.visibleDimensions[1],
       z = this.visibleDimensions[2], scope = this,
       is2D = (z === null), drawAll = (plottables === undefined);
-
-  positionsLeft = this.lines.left.geometry.attributes.position.array;
-  positionsRight = this.lines.right.geometry.attributes.position.array;
 
   this.decomp.edges.forEach(function(edge) {
     u = edge[0];
@@ -289,28 +286,15 @@ DecompositionView.prototype._redrawEdges = function(plottables) {
 
       center = [(u.coordinates[x] + v.coordinates[x]) / 2,
                 (u.coordinates[y] + v.coordinates[y]) / 2,
-                (u.coordinates[z] + v.coordinates[z]) / 2];
+                is2D ? 0 : (u.coordinates[z] + v.coordinates[z]) / 2];
 
-      left = [u.coordinates[x], u.coordinates[y], u.coordinates[z]];
-      right = [v.coordinates[x], v.coordinates[y], v.coordinates[z]];
+      left = [u.coordinates[x], u.coordinates[y],
+              is2D ? 0 : u.coordinates[z]];
+      right = [v.coordinates[x], v.coordinates[y],
+               is2D ? 0 : v.coordinates[z]];
 
-      positionsLeft[(j * 6)] = left[0] * scope.axesOrientation[0];
-      positionsLeft[(j * 6) + 1] = left[1] * scope.axesOrientation[1];
-      positionsLeft[(j * 6) + 2] = ((is2D ? 0 : left[2]) *
-                                    scope.axesOrientation[2]);
-      positionsLeft[(j * 6) + 3] = center[0] * scope.axesOrientation[0];
-      positionsLeft[(j * 6) + 4] = center[1] * scope.axesOrientation[1];
-      positionsLeft[(j * 6) + 5] = ((is2D ? 0 : center[2]) *
-                                    scope.axesOrientation[2]);
-
-      positionsRight[(j * 6)] = right[0] * scope.axesOrientation[0];
-      positionsRight[(j * 6) + 1] = right[1] * scope.axesOrientation[1];
-      positionsRight[(j * 6) + 2] = ((is2D ? 0 : right[2]) *
-                                     scope.axesOrientation[2]);
-      positionsRight[(j * 6) + 3] = center[0] * scope.axesOrientation[0];
-      positionsRight[(j * 6) + 4] = center[1] * scope.axesOrientation[1];
-      positionsRight[(j * 6) + 5] = ((is2D ? 0 : center[2]) *
-                                     scope.axesOrientation[2]);
+      scope.lines.left.setLineAtIndex(j, left, center);
+      scope.lines.right.setLineAtIndex(j, right, center);
     }
 
     j++;
@@ -448,10 +432,7 @@ DecompositionView.prototype.hideEdgesForPlottables = function(plottables) {
     return;
   }
 
-  var u, v, j = 0, positionsLeft, positionsRight, hideAll;
-
-  positionsLeft = this.lines.left.geometry.attributes.position.array;
-  positionsRight = this.lines.right.geometry.attributes.position.array;
+  var u, v, j = 0, hideAll, scope = this;
 
   hideAll = plottables === undefined;
 
@@ -461,21 +442,10 @@ DecompositionView.prototype.hideEdgesForPlottables = function(plottables) {
 
     if (hideAll ||
         (plottables.indexOf(u) !== -1 || plottables.indexOf(v) !== -1)) {
-      positionsLeft[(j * 6)] = 0;
-      positionsLeft[(j * 6) + 1] = 0;
-      positionsLeft[(j * 6) + 2] = 0;
-      positionsLeft[(j * 6) + 3] = 0;
-      positionsLeft[(j * 6) + 4] = 0;
-      positionsLeft[(j * 6) + 5] = 0;
 
-      positionsRight[(j * 6)] = 0;
-      positionsRight[(j * 6) + 1] = 0;
-      positionsRight[(j * 6) + 2] = 0;
-      positionsRight[(j * 6) + 3] = 0;
-      positionsRight[(j * 6) + 4] = 0;
-      positionsRight[(j * 6) + 5] = 0;
+      scope.lines.left.setLineAtIndex(j, [0, 0, 0], [0, 0, 0]);
+      scope.lines.right.setLineAtIndex(j, [0, 0, 0], [0, 0, 0]);
     }
-
     j++;
   });
 

--- a/emperor/support_files/js/visibility-controller.js
+++ b/emperor/support_files/js/visibility-controller.js
@@ -86,6 +86,8 @@ define([
 
     _.each(this.decompViewDict, function(view) {
       scope.setPlottableAttributes(view, true, view.decomp.plottable);
+      view.showEdgesForPlottables();
+
       view.needsUpdate = true;
     });
   };
@@ -111,6 +113,14 @@ define([
         scope.ellipsoids[idx].visible = visible;
       }
     });
+
+    if (visible === true) {
+      scope.showEdgesForPlottables(group);
+    }
+    else {
+      scope.hideEdgesForPlottables(group);
+    }
+
     scope.needsUpdate = true;
   };
 

--- a/tests/javascript_tests/test_decomposition_view.js
+++ b/tests/javascript_tests/test_decomposition_view.js
@@ -385,5 +385,47 @@ requirejs([
 
       deepEqual(dv.axesOrientation, [1, -1, 1]);
     });
+
+    test('Test showEdgesForPlottables', function() {
+      var dv = new DecompositionView(this.decompWithEdges);
+
+      dv.hideEdgesForPlottables();
+
+      dv.showEdgesForPlottables();
+
+      exp = [-0.2765420079231262, -0.14496399462223053, 0.0666470006108284,
+             -0.25710150599479675, -0.04945550113916397,
+             -0.035744499415159225];
+      exp = new Float32Array(exp);
+      deepEqual(dv.lines.left.geometry.attributes.position.array, exp);
+
+      exp = [-0.23766100406646729, 0.046052999794483185, -0.13813599944114685,
+             -0.25710150599479675, -0.04945550113916397,
+             -0.035744499415159225];
+
+      exp = new Float32Array(exp);
+      deepEqual(dv.lines.right.geometry.attributes.position.array, exp);
+
+      // shouldn't error and work fine
+      dv.showEdgesForPlottables('Not a plottable');
+
+    });
+
+    test('Test hideEdgesForPlottables', function() {
+      var dv = new DecompositionView(this.decompWithEdges);
+
+      dv.hideEdgesForPlottables();
+
+      exp = [0, 0, 0, 0, 0, 0];
+      exp = new Float32Array(exp);
+      deepEqual(dv.lines.left.geometry.attributes.position.array, exp);
+
+      exp = [0, 0, 0, 0, 0, 0];
+      exp = new Float32Array(exp);
+      deepEqual(dv.lines.right.geometry.attributes.position.array, exp);
+
+      dv.hideEdgesForPlottables('Not a plottable');
+    });
+
   });
 });


### PR DESCRIPTION
For procrustes plots edges were not being hidden when samples in it were. Demo:

![procrustes-bug](https://user-images.githubusercontent.com/375307/38704852-a4804264-3e75-11e8-8001-7e1cab8a8740.gif)


Fixes #193