### PR TITLE
BUG: Fix problem with label sizes

### DIFF
--- a/tests/javascript_tests/test_draw.js
+++ b/tests/javascript_tests/test_draw.js
@@ -76,59 +76,62 @@ requirejs(['draw', 'three'], function(draw, THREE) {
 
     /**
      *
-     * Test that makeLabel works correctly without a factor
+     * Test that makeLabel works correctly.
+     *
+     * The validity of the scaling factor was tested visually and by hand.
      *
      */
     test('Test makeLabel works correctly', function(assert) {
-      var label = makeLabel([0, 0, 0], 'foolibusters', 0x00FF00);
+      var label = makeLabel([0, 0, 0], 'ab', 0x00FF00);
 
       equal(label.material.color.r, 0);
       equal(label.material.color.g, 1);
       equal(label.material.color.b, 0);
 
-      equal(label.position.x, 0);
-      equal(label.position.y, 0);
-      equal(label.position.z, 0);
-
-      equal(label.text, 'foolibusters');
+      deepEqual(label.position.toArray(), [0, 0, 0]);
+      equal(label.text, 'ab');
+      deepEqual(label.scale.toArray(), [0.1625, 0.08125, 1]);
     });
 
     /**
      *
-     * Test that makeLabel works correctly without a factor and a color name
+     * Test that makeLabel works correctly for long strings.
+     *
+     * The validity of the scaling factor was tested visually and by hand.
      *
      */
     test('Test makeLabel works correctly with color name', function(assert) {
-      var label = makeLabel([0, 0, 0], 'foolibusters', 'red');
+      var label = makeLabel([0, 0, 0], 'DaysSinceExperimentStart', 'red');
 
       equal(label.material.color.r, 1);
       equal(label.material.color.g, 0);
       equal(label.material.color.b, 0);
 
-      equal(label.position.x, 0);
-      equal(label.position.y, 0);
-      equal(label.position.z, 0);
-
-      equal(label.text, 'foolibusters');
+      deepEqual(label.position.toArray(), [0, 0, 0]);
+      equal(label.text, 'DaysSinceExperimentStart');
+      deepEqual(label.scale.toArray(),
+                [0.9333333333333332, 0.05833333333333333, 1]);
     });
 
     /**
      *
-     * Test that makeLabel works correctly with a factor.
+     * Test that makeLabel works correctly with small and large sizes
+     *
+     * The validity of the scaling factor was tested visually and by hand.
      *
      */
-    test('Test makeLabel works correctly', function(assert) {
-      var label = makeLabel([0, 0, 0], 'foolibusters', 0xFFFF00, 20);
+    test('Test makeLabel scales right', function(assert) {
+      var label = makeLabel([0, 0, 0], 'Axis 1 (35.17 %)', 0xFFFF00);
 
       equal(label.material.color.r, 1);
       equal(label.material.color.g, 1);
       equal(label.material.color.b, 0);
 
-      equal(label.position.x, 0);
-      equal(label.position.y, 0);
-      equal(label.position.z, 0);
+      deepEqual(label.position.toArray(), [0, 0, 0]);
+      equal(label.text, 'Axis 1 (35.17 %)');
 
-      equal(label.text, 'foolibusters');
+      deepEqual(label.scale.toArray(), [0.5, 0.0625, 1]);
+
     });
 
     test('Test makeArrow works correctly', function(assert) {


### PR DESCRIPTION
The font sizes would become too small when the text was long and really big when the text was small. I've put in a few scaling factors to make the fonts look good in both cases, and have the "baseline" case be the string `Axis 1 (XX.XX %)`. 

# before bug fix

For long text the font is too small (see the `DaysSinceExperimentStart` label on the first axis).

![bad-size-long-string](https://user-images.githubusercontent.com/375307/39031481-54c2e738-441d-11e8-95c1-b3adb6ad664f.png)

For short text the font is too large (see the `ab` label on the first axis).

![bad-size-small-string](https://user-images.githubusercontent.com/375307/39031487-58eed7f4-441d-11e8-913f-d5a0012e9bc2.png)

# after bug fix

For both cases the font looks *good* now:

![good-size-long-string](https://user-images.githubusercontent.com/375307/39031488-5da94e6e-441d-11e8-8956-a48c1a26cacf.png)

![good-size-small-string](https://user-images.githubusercontent.com/375307/39031494-639349ba-441d-11e8-9d2b-e11dd2b787c5.png)

-----------


