### PR TITLE
ENH: Add menu item to hide biplot labels

### DIFF
--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -580,6 +580,13 @@ define([
             });
           }
         },
+        'labels' : {
+          name: 'Toggle label visibility',
+          visible: scope.decViews.biplot !== undefined,
+          callback: function() {
+            scope.decViews.biplot.toggleLabelVisibility();
+          }
+        },
         'sep0': '----------------',
         'saveState': {
           name: 'Save current settings',

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -808,6 +808,24 @@ DecompositionView.prototype.setOpacity = function(opacity, group) {
 };
 
 /**
+ * Toggles the visibility of arrow labels
+ *
+ * @throws {Error} if this method is called on a scatter type.
+ */
+DecompositionView.prototype.toggleLabelVisibility = function() {
+  if (this.decomp.isScatterType()) {
+    throw new Error('Cannot hide labels of scatter types');
+  }
+  var scope = this;
+
+  this.decomp.apply(function(plottable) {
+    arrow = scope.markers[plottable.idx];
+    arrow.label.visible = Boolean(arrow.label.visible ^ true);
+  });
+  this.needsUpdate = true;
+};
+
+/**
  * Helper function to change the opacity of an arrow object.
  *
  * @private

--- a/tests/javascript_tests/test_decomposition_view.js
+++ b/tests/javascript_tests/test_decomposition_view.js
@@ -390,6 +390,33 @@ requirejs([
       deepEqual(dv.axesOrientation, [1, -1, 1]);
     });
 
+    test('Test toggling label visibility errors', function(assert) {
+      var dv = new DecompositionView(this.decomp);
+
+      throws(
+        function() {
+          dv.toggleLabelVisibility();
+        },
+        Error, 'Scatter types cannot toggle label visibility'
+      );
+    });
+
+    test('Test toggling label visibility', function(assert) {
+      this.decomp.type = 'arrow';
+      var dv = new DecompositionView(this.decomp);
+      assert.equal(dv.markers[0].label.visible, true);
+      assert.equal(dv.markers[1].label.visible, true);
+
+      dv.toggleLabelVisibility();
+
+      assert.equal(dv.markers[0].label.visible, false);
+      assert.equal(dv.markers[1].label.visible, false);
+
+      dv.toggleLabelVisibility();
+
+      assert.equal(dv.markers[0].label.visible, true);
+      assert.equal(dv.markers[1].label.visible, true);
+    });
 
     /**
      *


### PR DESCRIPTION
The labels can get really crowded if a lot of features are shown on screen. This PR adds a menu item to hide arrow labels, demo:

![labels](https://user-images.githubusercontent.com/375307/40754829-1dc0bb1a-6430-11e8-95fa-2f0515e7a9ed.gif)

**Note**: I've noticed that there's a problem with the label size which is obvious for taxonomic names (see in the image above), I'm working on a fix but don't really anything yet.