### PR TITLE
ENH: Minor improvements to biplots UI

### DIFF
--- a/emperor/core.py
+++ b/emperor/core.py
@@ -642,7 +642,7 @@ class Emperor(object):
 
         if self.ordination.features is not None:
             bi_coords = self.ordination.features.values[:, :dims]
-            bi_coords /= np.max(np.abs(bi_coords))
+            bi_coords = bi_coords / np.max(np.abs(bi_coords))
             bi_coords = bi_coords.tolist()
             bi_ids = self.ordination.features.index.values.tolist()
 

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -87,7 +87,7 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
 
   /**
    *
-   * Check for ray casting with the line and cone of the arrow
+   * Check for ray casting with arrow's cone.
    *
    * This class may need to disappear if THREE.ArrowHelper implements the
    * raycast method, for more information see the [online documentation]
@@ -95,9 +95,12 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
    *
    */
   EmperorArrowHelper.prototype.raycast = function(raycaster, intersects) {
-      // don't raycast the label since that one is self-explanatory
-      this.line.raycast(raycaster, intersects);
-      this.cone.raycast(raycaster, intersects);
+    // Two considerations:
+    // * Don't raycast the label since that one is self-explanatory
+    // * Don't raycast to the line as it adds a lot of noise to the raycaster.
+    //   If raycasting is enabled for lines, this will result in incorrect
+    //   intersects showing as the closest to the ray i.e. wrong labels.
+    this.cone.raycast(raycaster, intersects);
   };
 
   /**


### PR DESCRIPTION
- Improve raycasting for arrows. Previously it would also check for
intersects with lines, which would lead to incorrect matches.

- Fix biplot coordinates computation so that it doesn't modify the
original array, instead it creates a copy. Prevents us from modifying
the inputed OrdinationResults object.