### PR TITLE
Improvements to label sizes

### DIFF
--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -59,25 +59,11 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     THREE.ArrowHelper.call(this, dir, origin, length, color, headLength,
                            headWidth);
 
-    // 16 is roughly the number of characters in "Axis 1 (XX.xx %)"
-    var pad, MIN = 16, paddedName = name;
-
     this.name = name;
     this.line.name = this.name;
     this.cone.name = this.name;
 
-    /*
-     * If the text's lenght is small it will be rendered as a blurry sprite by
-     * padding with spaces we ensure the length allows for a decent resolution.
-     */
-    if (this.name.length < MIN) {
-      pad = Math.round((MIN - this.name.length) / 2);
-
-      paddedName = paddedName.padStart(paddedName.length + pad);
-      paddedName = paddedName.padEnd(paddedName.length + pad);
-    }
-
-    this.label = makeLabel(this.cone.position.toArray(), paddedName, color);
+    this.label = makeLabel(this.cone.position.toArray(), this.name, color);
     this.add(this.label);
 
     return this;
@@ -319,6 +305,9 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
    * on the answer found
    * [here]{@link http://stackoverflow.com/a/14106703/379593}
    *
+   * The text is returned scaled to its size in pixels, hence you'll need to
+   * scale it down depending on the scene's dimensions.
+   *
    * @param {float[]} position The x, y, and z location of the label.
    * @param {string} text The text to be shown on screen.
    * @param {integer|string} Color Hexadecimal base that represents the color
@@ -328,12 +317,8 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
    * @function makeLabel
    **/
   function makeLabel(position, text, color) {
-
     // the font size determines the resolution relative to the sprite object
-    var fontSize = 30, canvas, context, measure, scalingFactor = 0.5;
-
-    // 1/16 is the ideal I tested, equivalent to the string 'Axis 1 (16.12 %)'
-    var ideal = 1 / 16, observed = 1 / text.length;
+    var fontSize = 32, canvas, context, measure;
 
     canvas = document.createElement('canvas');
     context = canvas.getContext('2d');
@@ -367,22 +352,9 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
         color: color
     });
 
-    // We need to rescale the sprite's size to make it look like the ideal case
-    // the 1.3 and 1.4 are values that I tested by hand and "looked good"
-    if (observed > ideal) {
-      // fewer characters than the "ideal"
-      scalingFactor = (ideal / observed) * 1.3;
-    }
-    else if (observed < ideal) {
-      // more characters than the "ideal"
-      scalingFactor = (observed / ideal) * 1.4;
-    }
-
     var sp = new THREE.Sprite(mat);
     sp.position.set(position[0], position[1], position[2]);
-
-    sp.scale.set(scalingFactor, (canvas.height / canvas.width) * scalingFactor,
-                 1);
+    sp.scale.set(canvas.width, canvas.height, 1);
 
     // add an extra attribute so we can render this properly when we use
     // SVGRenderer

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -283,6 +283,7 @@ define([
 
       for (j = 0; j < this.decViews[decViewName].markers.length; j++) {
         marker = this.decViews[decViewName].markers[j];
+        this.scene.add(marker);
 
         // only arrows include text as part of their markers
         if (isArrowType) {
@@ -322,7 +323,7 @@ define([
   ScenePlotView3D.prototype.getScalingConstant = function() {
     return (this.dimensionRanges.max[0] -
             this.dimensionRanges.min[0]) * 0.001;
-  }
+  };
 
   /**
    *

--- a/tests/javascript_tests/test_draw.js
+++ b/tests/javascript_tests/test_draw.js
@@ -90,7 +90,7 @@ requirejs(['draw', 'three'], function(draw, THREE) {
 
       deepEqual(label.position.toArray(), [0, 0, 0]);
       equal(label.text, 'ab');
-      deepEqual(label.scale.toArray(), [0.1625, 0.08125, 1]);
+      deepEqual(label.scale.toArray(), [64, 32, 1]);
     });
 
     /**
@@ -109,8 +109,7 @@ requirejs(['draw', 'three'], function(draw, THREE) {
 
       deepEqual(label.position.toArray(), [0, 0, 0]);
       equal(label.text, 'DaysSinceExperimentStart');
-      deepEqual(label.scale.toArray(),
-                [0.9333333333333332, 0.05833333333333333, 1]);
+      deepEqual(label.scale.toArray(), [512, 32, 1]);
     });
 
     /**
@@ -130,7 +129,7 @@ requirejs(['draw', 'three'], function(draw, THREE) {
       deepEqual(label.position.toArray(), [0, 0, 0]);
       equal(label.text, 'Axis 1 (35.17 %)');
 
-      deepEqual(label.scale.toArray(), [0.5, 0.0625, 1]);
+      deepEqual(label.scale.toArray(), [256, 32, 1]);
 
     });
 

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -309,6 +309,8 @@ requirejs([
         equal(label.material.color.r, 0);
         equal(label.material.color.g, 1);
         equal(label.material.color.b, 0.058823529411764705);
+
+        deepEqual(label.scale.toArray(), [0.195158784, 0.024394848, 1]);
       }
 
       // release the control back to the main page
@@ -355,6 +357,16 @@ requirejs([
       spv.control.dispose();
     });
 
+    test('Test getScalingConstant', function(assert) {
+      var renderer = new THREE.SVGRenderer({antialias: true});
+      var spv = new ScenePlotView3D(renderer, this.sharedDecompositionViewDict,
+                                    'fooligans', 0, 0, 20, 20);
+
+      assert.equal(spv.getScalingConstant(), 0.000762339);
+
+      // release the control back to the main page
+      spv.control.dispose();
+    });
 
     /**
      *
@@ -433,12 +445,23 @@ requirejs([
       metadata = [['PC.636', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20070314'],
       ['PC.635', 'YATGCTGCCTCCCGTAGGAGT', 'Fast', '20071112']];
 
-      decomp = new DecompositionModel(data, md_headers, metadata);
+      decomp = new DecompositionModel(data, md_headers, metadata, 'arrow');
       dv = new DecompositionView(decomp);
+
+      // the label is not scaled upon creation
+      deepEqual(dv.markers[0].label.scale.toArray(), [128, 32, 1]);
+      deepEqual(dv.markers[1].label.scale.toArray(), [128, 32, 1]);
 
       this.sharedDecompositionViewDict.pleep = dv;
       spv.addDecompositionsToScene();
+
       equal(spv.scene.children.length, 13);
+
+      // after the labels are added to the scene, their scales change
+      deepEqual(dv.markers[0].label.scale.toArray(),
+                [0.097579392, 0.024394848, 1]);
+      deepEqual(dv.markers[1].label.scale.toArray(),
+                [0.097579392, 0.024394848, 1]);
 
       // release the control back to the main page
       spv.control.dispose();


### PR DESCRIPTION
This PR adds a stable scaling for labels in the plot. It removes the changes put in as part of #667. While this was not a problem for axes labels, it was a big issue for biplot labels, see for example this plot and notice how the text has varying sizes:

![screen shot 2018-07-20 at 9 40 32 am](https://user-images.githubusercontent.com/375307/43014487-20829c58-8c01-11e8-82e9-70129401dfbb.png)

And after this PR, all the text in the scene has the same size, making it for a better looking plot:

![screen shot 2018-07-20 at 9 43 06 am](https://user-images.githubusercontent.com/375307/43014543-57688714-8c01-11e8-95cf-57e929b10985.png)

These changes make the text size constant by determining a scene-wide scaling (no more strange scalings scattered all over the place woooohooo! 🎉 ).