### PR TITLE
Fix glitch when centering the camera

### DIFF
--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -823,7 +823,6 @@ define([
    *
    */
   ScenePlotView3D.prototype.recenterCamera = function() {
-    this.control.update();
     this.camera.rotation.set(0, 0, 0);
     this.camera.updateProjectionMatrix();
 
@@ -832,6 +831,11 @@ define([
 
     // 5 is inspired by the old emperor.js and by the init method of this class
     this.camera.position.set(0, 0, max * 5);
+
+    // after all changes are made, reset the control
+    this.control.reset();
+    this.control.update();
+
     this.needsUpdate = true;
   };
 

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -667,7 +667,7 @@ requirejs([
      * Test the recenterCamera method for ScenePlotView3D
      *
      */
-    test('Test recenterCamera', function() {
+    test('Test recenterCamera', function(assert) {
 
       var renderer = new THREE.SVGRenderer({antialias: true}), max;
       var spv = new ScenePlotView3D(renderer, this.sharedDecompositionViewDict,
@@ -683,12 +683,18 @@ requirejs([
 
       spv.recenterCamera();
 
-      equal(spv.camera.rotation.x, 0);
-      equal(spv.camera.rotation.y, 0);
-      equal(spv.camera.rotation.z, 0);
+      // for some odd reason orbit controls makes the rotation close to zero
+      // but not actually zero and there's no "close to zero" method in Qunit
+      function closeToZero(x) {
+        x = Math.abs(x);
+        return x >= 0 && x < 0.0000001;
+      }
+      assert.ok(closeToZero(spv.camera.rotation.x));
+      assert.ok(closeToZero(spv.camera.rotation.y));
+      assert.ok(closeToZero(spv.camera.rotation.z));
 
-      equal(spv.camera.position.x, 0);
-      equal(spv.camera.position.y, 0);
+      assert.ok(closeToZero(spv.camera.position.x));
+      assert.ok(closeToZero(spv.camera.position.y));
       equal(spv.camera.position.z, max * 5);
 
       spv.control.dispose();


### PR DESCRIPTION
This PR fixes a problem where after re-centering the camera the whole plot would jump between locations. For example notice in this animation how after I recenter the plot *and rotate the plot*, it jumps between positions:

![old-centering](https://user-images.githubusercontent.com/375307/43019787-f634932c-8c12-11e8-8ef9-613f84cccdb0.gif)

After fixing this problem, the plot can be rotated after re-centering and there are not jumps or glitches:

![new-centering](https://user-images.githubusercontent.com/375307/43019824-0675d534-8c13-11e8-983d-54f8cc696379.gif)
