### PR TITLE
BUG: Fix version conflicts with Jupyter deps

### DIFF
--- a/emperor/support_files/templates/logic-template.html
+++ b/emperor/support_files/templates/logic-template.html
@@ -4,7 +4,11 @@
 </div>
 
 <script type="text/javascript">
-requirejs.config({
+// When running in the Jupyter notebook we've encountered version conflicts
+// with some dependencies. So instead of polluting the global require context,
+// we define a new context.
+var emperorRequire = require.config({
+'context': 'emperor',
 // the left side is the module name, and the right side is the path
 // relative to the baseUrl attribute, do NOT include the .js extension
 'paths': {
@@ -94,7 +98,7 @@ requirejs.config({
 }
 });
 
-requirejs(
+emperorRequire(
 ["jquery", "model", "controller"],
 function($, model, EmperorController) {
   var DecompositionModel = model.DecompositionModel;

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -75,7 +75,11 @@ if ($("#emperor-css").length == 0){{
 </div>
 
 <script type="text/javascript">
-requirejs.config({
+// When running in the Jupyter notebook we've encountered version conflicts
+// with some dependencies. So instead of polluting the global require context,
+// we define a new context.
+var emperorRequire = require.config({
+'context': 'emperor',
 // the left side is the module name, and the right side is the path
 // relative to the baseUrl attribute, do NOT include the .js extension
 'paths': {
@@ -165,7 +169,7 @@ requirejs.config({
 }
 });
 
-requirejs(
+emperorRequire(
 ["jquery", "model", "controller"],
 function($, model, EmperorController) {
   var DecompositionModel = model.DecompositionModel;
@@ -261,7 +265,11 @@ if ($("#emperor-css").length == 0){{
 </div>
 
 <script type="text/javascript">
-requirejs.config({
+// When running in the Jupyter notebook we've encountered version conflicts
+// with some dependencies. So instead of polluting the global require context,
+// we define a new context.
+var emperorRequire = require.config({
+'context': 'emperor',
 // the left side is the module name, and the right side is the path
 // relative to the baseUrl attribute, do NOT include the .js extension
 'paths': {
@@ -351,7 +359,7 @@ requirejs.config({
 }
 });
 
-requirejs(
+emperorRequire(
 ["jquery", "model", "controller"],
 function($, model, EmperorController) {
   var DecompositionModel = model.DecompositionModel;


### PR DESCRIPTION
Fixes a problem where Jupyter's require declarations would shadow
Emperor's. Specifically while using the newest version of the Jupyter
notebook jquery would be updated to version 3.x and that version is not
compatible with several dependencies of Emperor.

For now this fix ensures that there will be no version conflicts by
putting all our dependencies under their own context.

----------

In case someone runs into this problem, here's how the UI would look (notice the dropdown menus are not loaded properly and no categories are visible):

<img width="1086" alt="screen shot 2018-09-13 at 4 15 08 pm" src="https://user-images.githubusercontent.com/375307/45520902-6d228880-b770-11e8-9bb3-04e82baef103.png">

