### PR TITLE
Re-organize documentation

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -4,10 +4,14 @@
     <meta charset="utf-8">
     <title>Emperor</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- Fav and touch icons -->
+    <link rel="icon" href="img/favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
+
     <script type="text/javascript" src="bootstrap/js/jquery-2.2.3.min.js"></script>
     <script type="text/javascript" src="bootstrap/js/bootstrap.min.js"></script>
-    <meta name="description" content="">
-    <meta name="author" content="">
+
     <link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
     <style type="text/css">
       body {
@@ -42,9 +46,6 @@
     <!--[if lt IE 9]>
       <script src="bootstrap/js/html5shiv.js"></script>
     <![endif]-->
-
-    <!-- Fav and touch icons -->
-    <link rel="shortcut icon" href="img/favicon.ico">
   </head>
 
   <body>
@@ -61,12 +62,13 @@
                 <li class="dropdown">
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Documentation<span class="caret"></span></a>
                   <ul class="dropdown-menu">
+                    <li><a href="build/html/examples.html">Examples</a></li>
                     <li><a href="build/html/index.html">Python Documentation</a></li>
                     <li><a href="build/jsdoc/index.html">Javascript Documentation</a></li>
+                    <li><a href="build/html/description.html">Description</a></li>
                   </ul>
                 </li>
-                <li><a href="build/html/examples.html">Examples</a></li>
-                <li><a href="build/html/description.html">Description</a></li>
+                <li><a href="https://nbviewer.jupyter.org/github/biocore/emperor/tree/new-api/examples/">Notebooks</a></li>
                 <li><a href="https://github.com/biocore/emperor/blob/new-api/INSTALL.md#emperor-installation-notes">Installation</a></li>
                 <li><a href="https://github.com/biocore/emperor/issues">Support</a></li>
               </ul>

--- a/emperor/core.py
+++ b/emperor/core.py
@@ -73,6 +73,10 @@ class Emperor(object):
         DataFrame object with the metadata associated to the samples in the
         ``ordination`` object, should have an index set and it should match the
         identifiers in the ``ordination`` object.
+    feature_mapping_file: pd.DataFrame, optional
+        DataFrame object with the metadata associated to the features in the
+        ``ordination`` object, should have an index set and it should match the
+        identifiers in the ``ordination.features`` object.
     dimensions: int, optional
         Number of dimensions to keep from the ordination data, defaults to 5.
         Be aware that this value will determine the number of dimensions for


### PR DESCRIPTION
Adds missing documentation for the feature_mapping_file parameter and re-organizes the main documentation page. We now directly point to nbviewer with all the example notebooks. See the screencapture below (the Notebooks tab points to this [link](https://nbviewer.jupyter.org/github/biocore/emperor/tree/new-api/examples/)).

![screen shot 2018-09-28 at 10 53 37 am](https://user-images.githubusercontent.com/375307/46224996-d4157500-c30c-11e8-90e8-db2f46572445.png)
