### PR TITLE
BUG: Fix a bug with the red-yellow-blue colormap

### DIFF
--- a/emperor/support_files/js/color-view-controller.js
+++ b/emperor/support_files/js/color-view-controller.js
@@ -584,7 +584,7 @@ define([
     {id: 'Spectral', name: 'Spectral', type: DIVERGING},
     {id: 'RdBu', name: 'Red-Blue', type: DIVERGING},
     {id: 'RdYlGn', name: 'Red-Yellow-Green', type: DIVERGING},
-    {id: 'RdYlB', name: 'Red-Yellow-Blue', type: DIVERGING},
+    {id: 'RdYlBu', name: 'Red-Yellow-Blue', type: DIVERGING},
     {id: 'RdGy', name: 'Red-Grey', type: DIVERGING},
     {id: 'PiYG', name: 'Pink-Yellow-Green', type: DIVERGING},
     {id: 'BrBG', name: 'Brown-Blue-Green', type: DIVERGING},


### PR DESCRIPTION
There was a typo in the name of the colormap that prevented the data
from being colored correctly.

## Before (notice the color selection menu)

<img width="1125" alt="screen shot 2018-10-03 at 5 24 20 pm" src="https://user-images.githubusercontent.com/375307/46446546-bc395900-c731-11e8-9d15-a6cc7e6e3f16.png">


## After

<img width="1114" alt="screen shot 2018-10-03 at 5 25 52 pm" src="https://user-images.githubusercontent.com/375307/46446550-c0657680-c731-11e8-87dc-e5090a98c252.png">
