### PR TITLE
Fixes problem with the camera not being centered

### DIFF
--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -332,7 +332,7 @@ define([
     }
 
     var spv = new ScenePlotView3D(this.renderer, this.decViews,
-                                  this.$plotSpace, 0, 0, 0, 0);
+                                  this.$plotSpace, 0, 0, this.width, this.height);
     this.sceneViews.push(spv);
 
     // this will setup the appropriate sizes and widths

--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -332,7 +332,8 @@ define([
     }
 
     var spv = new ScenePlotView3D(this.renderer, this.decViews,
-                                  this.$plotSpace, 0, 0, this.width, this.height);
+                                  this.$plotSpace, 0, 0,
+                                  this.width, this.height);
     this.sceneViews.push(spv);
 
     // this will setup the appropriate sizes and widths

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -661,7 +661,7 @@ define([
     this.updateCameraAspectRatio();
 
     this.control.saveState();
-  }
+  };
 
   /**
    *

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -89,6 +89,11 @@ define([
     this.dimensionRanges = {'max': [], 'min': []};
     this._unionRanges();
 
+    var owidth = this.dimensionRanges.max[0] - this.dimensionRanges.min[0];
+    var oheight = this.dimensionRanges.max[1] - this.dimensionRanges.min[1];
+    console.log('WORLD width ', owidth, 'height ', oheight);
+    console.log('SCREEN width ', this.width, 'height ', this.height);
+
     // used to name the axis lines/labels in the scene
     this._axisPrefix = 'emperor-axis-line-';
     this._axisLabelPrefix = 'emperor-axis-label-';
@@ -656,8 +661,8 @@ define([
     this.camera.position.set(xcenter, ycenter, max * 5);
     this.camera.updateProjectionMatrix();
 
-    this.control.target0 = this.control.target.clone();
-    this.control.position0 = this.camera.position.clone();
+    this.control.target0.copy(this.control.target);
+    this.control.position0.copy(this.camera.position);
 
     // this calls control.update
     this.updateCameraAspectRatio();
@@ -880,12 +885,16 @@ define([
    *
    */
   ScenePlotView3D.prototype.recenterCamera = function() {
+    this.control.reset();
     this.camera.rotation.set(0, 0, 0);
+    this.camera.position.copy(this.control.position0);
     this.camera.updateProjectionMatrix();
 
     // after all changes are made, reset the control
-    this.control.reset();
     this.control.update();
+
+    console.log('The camera is not being centered', this.camera.position, this.control.target0);
+    console.log('distance ', this.camera.position.distanceTo(this.control.position0));
 
     this.needsUpdate = true;
   };

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -639,6 +639,10 @@ define([
 
   /**
    * Updates the target and dimensions of the camera and control
+   *
+   * The target of the scene depends on the coordinate space of the data, by
+   * default it is set to zero, but we need to make sure that the target is
+   * reasonable for the data.
    */
   ScenePlotView3D.prototype.updateCameraTarget = function() {
     var x = this.visibleDimensions[0], y = this.visibleDimensions[1];

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -89,11 +89,6 @@ define([
     this.dimensionRanges = {'max': [], 'min': []};
     this._unionRanges();
 
-    var owidth = this.dimensionRanges.max[0] - this.dimensionRanges.min[0];
-    var oheight = this.dimensionRanges.max[1] - this.dimensionRanges.min[1];
-    console.log('WORLD width ', owidth, 'height ', oheight);
-    console.log('SCREEN width ', this.width, 'height ', this.height);
-
     // used to name the axis lines/labels in the scene
     this._axisPrefix = 'emperor-axis-line-';
     this._axisLabelPrefix = 'emperor-axis-label-';
@@ -145,8 +140,6 @@ define([
     this.control.panSpeed = 0.8;
     this.control.enableZoom = true;
     this.control.enablePan = true;
-    this.control.enableDamping = true;
-    this.control.dampingFactor = 0.3;
     this.control.addEventListener('change', function() {
       scope.needsUpdate = true;
     });
@@ -661,11 +654,9 @@ define([
     this.camera.position.set(xcenter, ycenter, max * 5);
     this.camera.updateProjectionMatrix();
 
-    this.control.target0.copy(this.control.target);
-    this.control.position0.copy(this.camera.position);
-
-    // this calls control.update
     this.updateCameraAspectRatio();
+
+    this.control.saveState();
   }
 
   /**
@@ -886,15 +877,7 @@ define([
    */
   ScenePlotView3D.prototype.recenterCamera = function() {
     this.control.reset();
-    this.camera.rotation.set(0, 0, 0);
-    this.camera.position.copy(this.control.position0);
-    this.camera.updateProjectionMatrix();
-
-    // after all changes are made, reset the control
     this.control.update();
-
-    console.log('The camera is not being centered', this.camera.position, this.control.target0);
-    console.log('distance ', this.camera.position.distanceTo(this.control.position0));
 
     this.needsUpdate = true;
   };

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -697,7 +697,7 @@ requirejs([
                                     'fooligans', 0, 0, 20, 20);
 
       // should be the center of the scene
-      var center = spv.control.target0.clone();
+      var reset = spv.control.position0.clone();
 
       spv.camera.rotation.set(1, 1, 1);
       spv.camera.position.set(-1, 11, 0);
@@ -705,15 +705,6 @@ requirejs([
       spv.control.update();
       spv.needsUpdate = true;
 
-      max = _.max(spv.dimensionRanges.max);
-
-      spv.recenterCamera();
-      spv.recenterCamera();
-      spv.recenterCamera();
-      spv.recenterCamera();
-      spv.recenterCamera();
-      spv.recenterCamera();
-      spv.recenterCamera();
       spv.recenterCamera();
 
       // for some odd reason orbit controls makes the rotation close to zero
@@ -727,9 +718,7 @@ requirejs([
       assert.ok(closeToZero(spv.camera.rotation.y));
       assert.ok(closeToZero(spv.camera.rotation.z));
 
-      console.log('camera distance to center is ', spv.camera.position.distanceTo(center));
-      console.log('camera position is ', spv.camera.position);
-      assert.ok(closeToZero(spv.camera.position.distanceTo(center)));
+      assert.ok(closeToZero(spv.camera.position.distanceTo(reset)));
 
       spv.control.dispose();
     });

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -696,14 +696,24 @@ requirejs([
       var spv = new ScenePlotView3D(renderer, this.sharedDecompositionViewDict,
                                     'fooligans', 0, 0, 20, 20);
 
+      // should be the center of the scene
+      var center = spv.control.target0.clone();
+
       spv.camera.rotation.set(1, 1, 1);
-      spv.camera.updateProjectionMatrix();
       spv.camera.position.set(-1, 11, 0);
       spv.camera.updateProjectionMatrix();
+      spv.control.update();
       spv.needsUpdate = true;
 
       max = _.max(spv.dimensionRanges.max);
 
+      spv.recenterCamera();
+      spv.recenterCamera();
+      spv.recenterCamera();
+      spv.recenterCamera();
+      spv.recenterCamera();
+      spv.recenterCamera();
+      spv.recenterCamera();
       spv.recenterCamera();
 
       // for some odd reason orbit controls makes the rotation close to zero
@@ -712,13 +722,14 @@ requirejs([
         x = Math.abs(x);
         return x >= 0 && x < 0.0000001;
       }
+
       assert.ok(closeToZero(spv.camera.rotation.x));
       assert.ok(closeToZero(spv.camera.rotation.y));
       assert.ok(closeToZero(spv.camera.rotation.z));
 
-      assert.ok(closeToZero(spv.camera.position.x));
-      assert.ok(closeToZero(spv.camera.position.y));
-      equal(spv.camera.position.z, max * 5);
+      console.log('camera distance to center is ', spv.camera.position.distanceTo(center));
+      console.log('camera position is ', spv.camera.position);
+      assert.ok(closeToZero(spv.camera.position.distanceTo(center)));
 
       spv.control.dispose();
     });

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -107,6 +107,14 @@ requirejs([
                                           -0.247485, -0.115211, -0.229889,
                                           -0.046599]);
 
+      // check that updateCameraTarget is working as expected
+      var expTarget = new THREE.Vector3(-0.6188305, -0.0494555, 0);
+      assert.ok(spv.control.target.distanceTo(expTarget) <= Number.EPSILON);
+
+      var expPosition = expTarget.clone();
+      expPosition.z = 0.88035;
+      assert.ok(spv.camera.position.distanceTo(expPosition) <= Number.EPSILON);
+
       // raycasting properties
       assert.ok(spv._raycaster instanceof THREE.Raycaster);
       assert.ok(spv._mouse instanceof THREE.Vector2);
@@ -697,7 +705,7 @@ requirejs([
                                     'fooligans', 0, 0, 20, 20);
 
       // should be the center of the scene
-      var reset = spv.control.position0.clone();
+      var reset = spv.control.position0.clone(), zero = new THREE.Vector3();
 
       spv.camera.rotation.set(1, 1, 1);
       spv.camera.position.set(-1, 11, 0);
@@ -707,20 +715,42 @@ requirejs([
 
       spv.recenterCamera();
 
-      // for some odd reason orbit controls makes the rotation close to zero
-      // but not actually zero and there's no "close to zero" method in Qunit
-      function closeToZero(x) {
-        x = Math.abs(x);
-        return x >= 0 && x < 0.0000001;
-      }
-
-      assert.ok(closeToZero(spv.camera.rotation.x));
-      assert.ok(closeToZero(spv.camera.rotation.y));
-      assert.ok(closeToZero(spv.camera.rotation.z));
-
-      assert.ok(closeToZero(spv.camera.position.distanceTo(reset)));
+      assert.ok(spv.camera.rotation.x <= Number.EPSILON);
+      assert.ok(spv.camera.rotation.y <= Number.EPSILON);
+      assert.ok(spv.camera.rotation.z <= Number.EPSILON);
+      assert.ok(spv.camera.position.distanceTo(reset) <= Number.EPSILON);
 
       spv.control.dispose();
     });
+
+    /**
+     *
+     * Test the updateCameraTarget method for ScenePlotView3D
+     *
+     */
+    test('Test updateCameraTarget', function(assert) {
+
+      var renderer = new THREE.SVGRenderer({antialias: true}), max;
+      var spv = new ScenePlotView3D(renderer, this.sharedDecompositionViewDict,
+                                    'fooligans', 0, 0, 20, 20);
+      spv.visibleDimensions = [1, 2, 3];
+      spv.updateCameraTarget();
+
+      var top = 0.1023915, bottom = -top, right = 0.1023915, left = -right;
+      var target = new THREE.Vector3(-0.0494555, -0.0357445, 0);
+      var position = new THREE.Vector3(-0.0494555, -0.0357445, 0.88035);
+
+      assert.ok((spv.camera.top - top) < Number.EPSILON);
+      assert.ok((spv.camera.bottom - bottom) < Number.EPSILON);
+      assert.ok((spv.camera.left - left) < Number.EPSILON);
+      assert.ok((spv.camera.right - right) < Number.EPSILON);
+
+      // also check the position
+      assert.ok(spv.control.target.distanceTo(target) < Number.EPSILON);
+      assert.ok(spv.camera.position.distanceTo(position) < Number.EPSILON);
+
+      spv.control.dispose();
+    });
+
   });
 });


### PR DESCRIPTION
Fixes #696 

The problem was that the camera assumed all coordinate spaces were centered around the origin. This assumption is not always true and it is **almost always** not true for weighted UniFrac (hence the panning of the camera in the screenshot in #696). While fixing this, I noticed that the target of the camera had an offset making plots rotate in an awkward way, this was fixed by adding calculating the target.

I also noticed that "re-centering" wasn't working properly either, re-centering the camera would lead to "almost" centered scenes. This last problem was fixed by disabling inertia/damping in the scene's controls.