### PR TITLE
BUG: Fix problem with two-dimensional data

### DIFF
--- a/emperor/core.py
+++ b/emperor/core.py
@@ -217,6 +217,7 @@ class Emperor(object):
     ValueError
         If the remote argument is not of ``bool`` or ``str`` type.
         If none of the samples in the ordination matrix are in the metadata.
+        If the data is one-dimensional.
     KeyError
         If there's samples in the ordination matrix but not in the metadata.
 
@@ -230,6 +231,10 @@ class Emperor(object):
     def __init__(self, ordination, mapping_file, feature_mapping_file=None,
                  dimensions=5, remote=True, jackknifed=None, procrustes=None,
                  ignore_missing_samples=False):
+
+        if ordination.samples.shape[1] < 2:
+            raise ValueError('Ordinations with less than two dimensions are'
+                             ' not supported.')
 
         self.ordination = ordination
         self.jackknifed = jackknifed if jackknifed is not None else []

--- a/emperor/support_files/js/animations-controller.js
+++ b/emperor/support_files/js/animations-controller.js
@@ -489,7 +489,7 @@ define([
     // get the current visible dimensions
     var x = view.visibleDimensions[0], y = view.visibleDimensions[1],
         z = view.visibleDimensions[2];
-    var is2D = (z === null);
+    var is2D = (z === null || z === undefined);
 
     gradient = this.$gradientSelect.val();
     trajectory = this.$trajectorySelect.val();

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -79,7 +79,7 @@ define([
      * axis ([x, y, z]).
      * @type {Integer[]}
      */
-    this.visibleDimensions = [0, 1, 2];
+    this.visibleDimensions = _.clone(this.decViews.scatter.visibleDimensions);
 
     /**
      * Ranges for all the decompositions in this view (there's a min and a max
@@ -425,7 +425,7 @@ define([
     // shortcut to the index of the visible dimension and the range object
     var x = this.visibleDimensions[0], y = this.visibleDimensions[1],
         z = this.visibleDimensions[2], range = this.dimensionRanges,
-        is2D = z === null;
+        is2D = (z === null || z === undefined);
 
     // Adds a padding to all dimensions such that samples don't overlap
     // with the axes lines. Determined based on the default sphere radius
@@ -456,11 +456,9 @@ define([
     action(start, ends[0], x);
     action(start, ends[1], y);
 
-    // when transitioning to 2D reset the camera and disable rotation to make
-    // the plot look straight at the camera, as opposed to an awkward angle
+    // when transitioning to 2D disable rotation to avoid awkward angles
     if (is2D) {
       this.control.enableRotate = false;
-      this.recenterCamera();
     }
     else {
       action(start, ends[2], z);
@@ -658,9 +656,13 @@ define([
     this.camera.position.set(xcenter, ycenter, max * 5);
     this.camera.updateProjectionMatrix();
 
+    this.light.position.set(xcenter, ycenter, max * 5);
+
     this.updateCameraAspectRatio();
 
     this.control.saveState();
+
+    this.needsUpdate = true;
   };
 
   /**

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -38,7 +38,7 @@ function DecompositionView(decomp, asPointCloud) {
    * Top visible dimensions
    * @type {integer[]}
    */
-  // this array should have at most three elements
+  // make sure we only use at most 3 elements
   this.visibleDimensions = _.range(this.decomp.dimensions).slice(0, 3);
   /**
    * Orientation of the axes, `-1` means the axis is flipped, `1` means the

--- a/tests/javascript_tests/test_decomposition_view.js
+++ b/tests/javascript_tests/test_decomposition_view.js
@@ -111,6 +111,45 @@ requirejs([
       //           "_genericSphere set correctly");
     });
 
+    /**
+     *
+     * Test that the Decomposition View object is initialized correctly
+     *
+     */
+    test('Test constructor with two dimensions', function() {
+
+      var data = {
+        name: 'pcoa',
+        sample_ids: ['PC.636', 'PC.635'],
+        coordinates: [[-0.276542, -0.144964], [-0.237661, 0.046053]],
+        percents_explained: [80.0, 20.0]};
+      var md_headers = ['SampleID', 'LinkerPrimerSequence', 'Treatment',
+                        'DOB'];
+      var metadata = [['PC.636', 'YATGCTGCCTCCCGTAGGAGT', 'Control',
+                       '20070314'],
+                      ['PC.635', 'YATGCTGCCTCCCGTAGGAGT', 'Fast',
+                       '20071112']];
+      decomp = new DecompositionModel(data, md_headers, metadata);
+
+      var obs;
+      var dv = new DecompositionView(decomp);
+
+      equal(dv.count, 2, 'count set correctly');
+      equal(dv.getVisibleCount(), 2, 'visibleCount set correctly');
+      deepEqual(dv.visibleDimensions, [0, 1],
+          'visibleDimensions set correctly');
+      deepEqual(dv.tubes, [], 'tubes set correctly');
+
+      equal(dv.axesColor, '#FFFFFF');
+      equal(dv.backgroundColor, '#000000');
+
+      deepEqual(dv.axesOrientation, [1, 1]);
+
+      deepEqual(dv.markers[0].position.toArray(), [-0.276542, -0.144964, 0]);
+      deepEqual(dv.markers[1].position.toArray(), [-0.237661, 0.046053, 0]);
+      deepEqual(dv.lines, {'left': null, 'right': null});
+    });
+
     test('Test constructor (biplot)', function(assert) {
       // this test is pretty much the same as above except for arrow types
       this.decomp.type = 'arrow';

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -752,5 +752,57 @@ requirejs([
       spv.control.dispose();
     });
 
+    /**
+     *
+     * Test object for 2D decomposition view
+     *
+     */
+    test('Test for 2D object', function(assert) {
+
+      var data = {name: 'PCOA',
+                  sample_ids: ['PC.636', 'PC.635'],
+                  coordinates: [[-0.276542, -0.144964],
+                                [-0.237661, 0.046053]],
+                  percents_explained: [80.0, 20.0]};
+      var md_headers = ['SampleID', 'LinkerPrimerSequence', 'Treatment',
+                        'DOB'];
+      var metadata = [
+        ['PC.636', 'YATGCTGCCTCCCGTAGGAGT', 'Control', '20070314'],
+        ['PC.635', 'YATGCTGCCTCCCGTAGGAGT', 'Fast', '20071112']
+      ];
+      var decomp = new DecompositionModel(data, md_headers, metadata);
+      var dv = new DecompositionView(decomp);
+
+      var renderer = new THREE.SVGRenderer({antialias: true}), max;
+      var spv = new ScenePlotView3D(renderer, {'scatter': dv},
+                                    'fooligans', 0, 0, 20, 20);
+
+      // do a checkup of the general attributes
+      deepEqual(spv.xView, 0);
+      deepEqual(spv.yView, 0);
+
+      equal(spv.width, 20);
+      equal(spv.height, 20);
+      equal(spv.checkUpdate(), true);
+
+      equal(spv.axesColor, '#FFFFFF');
+      equal(spv.backgroundColor, '#000000');
+
+      deepEqual(spv.visibleDimensions, [0, 1]);
+      deepEqual(spv.dimensionRanges.max, [-0.237661, 0.046053]);
+      deepEqual(spv.dimensionRanges.min, [-0.276542, -0.144964]);
+
+      // check that updateCameraTarget is working as expected
+      var expTarget = new THREE.Vector3(-0.2571015, -0.0494555, 0);
+      assert.ok(spv.control.target.distanceTo(expTarget) <= Number.EPSILON);
+
+      var expPosition = expTarget.clone();
+      expPosition.z = 0.230265;
+      assert.ok(spv.camera.position.distanceTo(expPosition) <= Number.EPSILON);
+
+      // release the control back to the main page
+      spv.control.dispose();
+    });
+
   });
 });

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -237,8 +237,6 @@ class TopLevelTests(TestCase):
         self.ord_res.proportion_explained = \
             self.ord_res.proportion_explained[:1].copy()
 
-        print(self.ord_res.samples)
-
         with self.assertRaisesRegexp(ValueError, "Ordinations with less than "
                                      "two dimensions are not supported"):
             Emperor(self.ord_res, self.mf, remote=False)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -231,6 +231,18 @@ class TopLevelTests(TestCase):
         self.assertEqual(emp.base_url, 'https://cdn.rawgit.com/biocore/emperor'
                                        '/new-api/emperor/support_files')
 
+    def test_one_dimensional(self):
+        self.ord_res.samples = self.ord_res.samples.iloc[:, :1].copy()
+        self.ord_res.eigvals = self.ord_res.eigvals.iloc[:1].copy()
+        self.ord_res.proportion_explained = \
+            self.ord_res.proportion_explained[:1].copy()
+
+        print(self.ord_res.samples)
+
+        with self.assertRaisesRegexp(ValueError, "Ordinations with less than "
+                                     "two dimensions are not supported"):
+            Emperor(self.ord_res, self.mf, remote=False)
+
     def test_initial_unbalanced(self):
         self.mf.drop(['PC.354'], inplace=True)
         with self.assertRaisesRegexp(KeyError, "There are samples not "


### PR DESCRIPTION
If the plot was initialized with two dimensions, the UI would fail to
instantiate as several objects had the dimensions hard-coded. I've
changed this to make it dependant on the data. In addition the Python
API will now check for one-dimensional data.

Fixes #686
Fixes #705