### PR TITLE
BUG: Fix bug with axis inversion in settings

### DIFF
--- a/emperor/support_files/js/axes-controller.js
+++ b/emperor/support_files/js/axes-controller.js
@@ -712,7 +712,8 @@ define([
     decView.changeVisibleDimensions(json.visibleDimensions);
 
     _.each(json.flippedAxes, function(element, index) {
-      if (element) {
+      // if the values are different, the axes need to be inverted
+      if (element !== scope._flippedAxes[index]) {
         scope.flipAxis(decView.visibleDimensions[index]);
       }
     });

--- a/tests/javascript_tests/test_axes_controller.js
+++ b/tests/javascript_tests/test_axes_controller.js
@@ -166,6 +166,27 @@ requirejs([
       deepEqual(this.controllerProcrustes.getOtherEdgeColor(), '#f0000f');
     });
 
+    test('Test fromJSON issue #717', function() {
+      // update the inversion of two axes before loading from JSON
+      this.controller.flipAxis(0);
+      this.controller.flipAxis(1);
+
+      deepEqual(this.controller._flippedAxes, [true, true, false]);
+
+      var json = {'flippedAxes': [false, true, true],
+                  'visibleDimensions': [0, 1, 2],
+                  'backgroundColor': '#FF00FF', 'axesColor': '#FF000F'};
+
+      this.controller.fromJSON(json);
+
+      var decView = this.controller.getView();
+      deepEqual(decView.visibleDimensions, [0, 1, 2]);
+      deepEqual(this.controller._flippedAxes, [false, true, true]);
+
+      deepEqual(decView.backgroundColor, '#FF00FF');
+      deepEqual(decView.axesColor, '#FF000F');
+    });
+
     test('Testing _colorChanged', function() {
       this.controller._colorChanged('axes-color', '#f0f0f0');
       deepEqual(this.controller.getAxesColor(), '#f0f0f0');


### PR DESCRIPTION
An axis would only be inverted if the loaded setting was "True", however
this would not honor the inversions that needed to happen if an axis was
currently set to True but should be changing to False.

I've included a unit test for this bug.

Fixes #717