### PR TITLE
Fast Animation

### DIFF
--- a/emperor/support_files/js/animate.js
+++ b/emperor/support_files/js/animate.js
@@ -137,7 +137,7 @@ function(_, trajectory) {
      * @default -1
      */
     this.currentFrame = -1;
-    
+
     /**
      * @type {Integer}
      * The previous frame served by the director
@@ -145,7 +145,7 @@ function(_, trajectory) {
      * but built more generically to allow rewind and frame skipping in the future)
      */
     this.previousFrame = -1;
-    
+
     /**
      * @type {Array}
      * Array where each element in the trajectory is a trajectory with the

--- a/emperor/support_files/js/animate.js
+++ b/emperor/support_files/js/animate.js
@@ -138,7 +138,7 @@ function(_, trajectory) {
      */
     this.currentFrame = -1;
     
-    /*
+    /**
      * @type {Integer}
      * The previous frame served by the director
      * (Note, more or less always equals currentFrame - 1 in current implementation,

--- a/emperor/support_files/js/animate.js
+++ b/emperor/support_files/js/animate.js
@@ -141,8 +141,6 @@ function(_, trajectory) {
     /**
      * @type {Integer}
      * The previous frame served by the director
-     * (Note, more or less always equals currentFrame - 1 in current implementation,
-     * but built more generically to allow rewind and frame skipping in the future)
      */
     this.previousFrame = -1;
 

--- a/emperor/support_files/js/animate.js
+++ b/emperor/support_files/js/animate.js
@@ -137,6 +137,15 @@ function(_, trajectory) {
      * @default -1
      */
     this.currentFrame = -1;
+    
+    /*
+     * @type {Integer}
+     * The previous frame served by the director
+     * (Note, more or less always equals currentFrame - 1 in current implementation,
+     * but built more generically to allow rewind and frame skipping in the future)
+     */
+    this.previousFrame = -1;
+    
     /**
      * @type {Array}
      * Array where each element in the trajectory is a trajectory with the
@@ -276,6 +285,7 @@ function(_, trajectory) {
    */
   AnimationDirector.prototype.updateFrame = function() {
     if (this.animationCycleFinished() === false) {
+      this.previousFrame = this.currentFrame;
       this.currentFrame = this.currentFrame + 1;
     }
   };

--- a/emperor/support_files/js/animations-controller.js
+++ b/emperor/support_files/js/animations-controller.js
@@ -459,7 +459,7 @@ define([
 
     view.staticTubes = [];
     view.dynamicTubes = [];
-   
+
     view.needsUpdate = true;
 
     this._updateButtons();
@@ -575,7 +575,7 @@ define([
         disposeTrajectoryLineDynamic(tube);
       }
     });
-    
+
     //Construct new dynamic tubes containing necessary interpolated segment for the current frame
     view.dynamicTubes = this.director.trajectories.map(function(trajectory) {
       var color = scope._colors[trajectory.metadataCategoryName] || 'red';

--- a/emperor/support_files/js/animations-controller.js
+++ b/emperor/support_files/js/animations-controller.js
@@ -443,8 +443,7 @@ define([
     this.playing = false;
     this.director = null;
 
-    var allTubes = view.staticTubes.concat(view.dynamicTubes);
-    allTubes.forEach(function(tube) {
+    view.getTubes().forEach(function(tube) {
       if (tube !== null && tube.parent !== null) {
         tube.parent.remove(tube);
       }
@@ -544,8 +543,7 @@ define([
     var radius = view.getGeometryFactor();
     radius *= 0.45 * this.getRadius();
 
-    var i = 0;
-    for (i = 0; i < this.director.trajectories.length; i++) {
+    for (var i = 0; i < this.director.trajectories.length; i++) {
       var trajectory = this.director.trajectories[i];
 
       //Ensure static tubes are constructed

--- a/emperor/support_files/js/animations-controller.js
+++ b/emperor/support_files/js/animations-controller.js
@@ -10,7 +10,6 @@ define([
 ], function($, _, DecompositionView, ViewControllers, AnimationDirector,
             draw, Color, ColorViewController) {
   var EmperorViewController = ViewControllers.EmperorViewController;
-  var drawTrajectoryLine = draw.drawTrajectoryLine;
   var drawTrajectoryLineStatic = draw.drawTrajectoryLineStatic;
   var drawTrajectoryLineDynamic = draw.drawTrajectoryLineDynamic;
   var updateStaticTrajectoryDrawRange = draw.updateStaticTrajectoryDrawRange;

--- a/emperor/support_files/js/animations-controller.js
+++ b/emperor/support_files/js/animations-controller.js
@@ -11,6 +11,9 @@ define([
             draw, Color, ColorViewController) {
   var EmperorViewController = ViewControllers.EmperorViewController;
   var drawTrajectoryLine = draw.drawTrajectoryLine;
+  var drawTrajectoryLineStatic = draw.drawTrajectoryLineStatic;
+  var drawTrajectoryLineDynamic = draw.drawTrajectoryLineDynamic;
+  var updateStaticTrajectoryDrawRange = draw.updateStaticTrajectoryDrawRange;
   var ColorEditor = Color.ColorEditor, ColorFormatter = Color.ColorFormatter;
 
   /**
@@ -440,13 +443,16 @@ define([
     this.playing = false;
     this.director = null;
 
-    view.tubes.forEach(function(tube) {
-      if (tube.parent !== null) {
+    var allTubes = view.staticTubes.concat(view.dynamicTubes);
+    allTubes.forEach(function(tube) {
+      if (tube !== null && tube.parent !== null) {
         tube.parent.remove(tube);
       }
     });
 
-    view.tubes = [];
+    view.staticTubes = [];
+    view.dynamicTubes = [];
+   
     view.needsUpdate = true;
 
     this._updateButtons();
@@ -538,19 +544,35 @@ define([
     var radius = view.getGeometryFactor();
     radius *= 0.45 * this.getRadius();
 
-    view.tubes.forEach(function(tube) {
-      if (tube === undefined) {
+    var i = 0;
+    for (i = 0; i < this.director.trajectories.length; i++) {
+      var trajectory = this.director.trajectories[i];
+
+      //Ensure static tubes are constructed
+      if (view.staticTubes[i] === null || view.staticTubes[i] === undefined)
+      {
+        var color = this._colors[trajectory.metadataCategoryName] || 'red';
+        view.staticTubes[i] = drawTrajectoryLineStatic(trajectory, color, radius);
+      }
+
+      //Ensure static tube draw ranges are set to visible segment
+      updateStaticTrajectoryDrawRange(trajectory, this.director.currentFrame, view.staticTubes[i]);
+    }
+
+    //Remove any old dynamic tubes from the scene
+    view.dynamicTubes.forEach(function(tube) {
+      if (tube === undefined || tube === null) {
         return;
       }
       if (tube.parent !== null) {
         tube.parent.remove(tube);
       }
     });
-
-    view.tubes = this.director.trajectories.map(function(trajectory) {
-      color = scope._colors[trajectory.metadataCategoryName] || 'red';
-
-      var tube = drawTrajectoryLine(trajectory, scope.director.currentFrame,
+    
+    //Construct new dynamic tubes containing necessary interpolated segment for the current frame
+    view.dynamicTubes = this.director.trajectories.map(function(trajectory) {
+      var color = scope._colors[trajectory.metadataCategoryName] || 'red';
+      var tube = drawTrajectoryLineDynamic(trajectory, scope.director.currentFrame,
                                     color, radius);
       return tube;
     });

--- a/emperor/support_files/js/animations-controller.js
+++ b/emperor/support_files/js/animations-controller.js
@@ -12,6 +12,8 @@ define([
   var EmperorViewController = ViewControllers.EmperorViewController;
   var drawTrajectoryLineStatic = draw.drawTrajectoryLineStatic;
   var drawTrajectoryLineDynamic = draw.drawTrajectoryLineDynamic;
+  var disposeTrajectoryLineStatic = draw.disposeTrajectoryLineStatic;
+  var disposeTrajectoryLineDynamic = draw.disposeTrajectoryLineDynamic;
   var updateStaticTrajectoryDrawRange = draw.updateStaticTrajectoryDrawRange;
   var ColorEditor = Color.ColorEditor, ColorFormatter = Color.ColorFormatter;
 
@@ -442,9 +444,16 @@ define([
     this.playing = false;
     this.director = null;
 
-    view.getTubes().forEach(function(tube) {
+    view.staticTubes.forEach(function(tube) {
       if (tube !== null && tube.parent !== null) {
         tube.parent.remove(tube);
+        disposeTrajectoryLineStatic(tube);
+      }
+    });
+    view.dynamicTubes.forEach(function(tube) {
+      if (tube !== null && tube.parent !== null) {
+        tube.parent.remove(tube);
+        disposeTrajectoryLineDynamic(tube);
       }
     });
 
@@ -563,6 +572,7 @@ define([
       }
       if (tube.parent !== null) {
         tube.parent.remove(tube);
+        disposeTrajectoryLineDynamic(tube);
       }
     });
     

--- a/emperor/support_files/js/animations-controller.js
+++ b/emperor/support_files/js/animations-controller.js
@@ -558,11 +558,15 @@ define([
       if (view.staticTubes[i] === null || view.staticTubes[i] === undefined)
       {
         var color = this._colors[trajectory.metadataCategoryName] || 'red';
-        view.staticTubes[i] = drawTrajectoryLineStatic(trajectory, color, radius);
+        view.staticTubes[i] = drawTrajectoryLineStatic(trajectory,
+                                                        color,
+                                                        radius);
       }
 
       //Ensure static tube draw ranges are set to visible segment
-      updateStaticTrajectoryDrawRange(trajectory, this.director.currentFrame, view.staticTubes[i]);
+      updateStaticTrajectoryDrawRange(trajectory,
+                                        this.director.currentFrame,
+                                        view.staticTubes[i]);
     }
 
     //Remove any old dynamic tubes from the scene
@@ -576,11 +580,14 @@ define([
       }
     });
 
-    //Construct new dynamic tubes containing necessary interpolated segment for the current frame
+    //Construct new dynamic tubes containing necessary
+    //interpolated segment for the current frame
     view.dynamicTubes = this.director.trajectories.map(function(trajectory) {
       var color = scope._colors[trajectory.metadataCategoryName] || 'red';
-      var tube = drawTrajectoryLineDynamic(trajectory, scope.director.currentFrame,
-                                    color, radius);
+      var tube = drawTrajectoryLineDynamic(trajectory,
+                                    scope.director.currentFrame,
+                                    color,
+                                    radius);
       return tube;
     });
 

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -287,7 +287,8 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     // https://github.com/mrdoob/three.js/wiki/Drawing-lines
     var material, points = [], lineGeometry, limit = 0, path;
 
-    _trajectory = trajectory.representativeInterpolatedCoordinatesAtIndex(currentFrame);
+    _trajectory = trajectory.representativeInterpolatedCoordinatesAtIndex(
+                                                                  currentFrame);
     if (_trajectory === null || _trajectory.length == 0)
       return null;
 
@@ -305,8 +306,11 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     // the line will contain the two vertices and the described material
     // we increase the number of points to have a smoother transition on
     // edges i. e. where the trajectory changes the direction it is going
-    lineGeometry = new THREE.TubeGeometry(path, (points.length - 1) * NUM_TUBE_SEGMENTS, radius,
-                                          NUM_TUBE_CROSS_SECTION_POINTS, false);
+    lineGeometry = new THREE.TubeGeometry(path,
+                                    (points.length - 1) * NUM_TUBE_SEGMENTS,
+                                    radius,
+                                    NUM_TUBE_CROSS_SECTION_POINTS,
+                                    false);
 
     return new THREE.Mesh(lineGeometry, material);
   }
@@ -338,9 +342,14 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
 
     var path = new THREE.EmperorTrajectory(allPoints);
 
-    //Tubes are straight segments, but adding vertices along them might change lighting effects
-    //under certain models and lighting conditions.
-    var tubeBufferGeom = new THREE.TubeBufferGeometry(path, (allPoints.length - 1) * NUM_TUBE_SEGMENTS, radius, NUM_TUBE_CROSS_SECTION_POINTS, false);
+    //Tubes are straight segments, but adding vertices along them might change
+    //lighting effects under certain models and lighting conditions.
+    var tubeBufferGeom = new THREE.TubeBufferGeometry(
+                                path,
+                                (allPoints.length - 1) * NUM_TUBE_SEGMENTS,
+                                radius,
+                                NUM_TUBE_CROSS_SECTION_POINTS,
+                                false);
 
     return new THREE.Mesh(tubeBufferGeom, material);
   }
@@ -355,9 +364,12 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
 
   function updateStaticTrajectoryDrawRange(trajectory, currentFrame, threeMesh)
   {
-    //Reverse engineering the number of points in a THREE tube is not fun, and may be implementation/version dependent.
-    //Number of points drawn per tube segment = 2 (triangles) * 3 (points per triangle) * NUM_TUBE_CROSS_SECTION_POINTS (number of vertices in a cross section of tube)
-    //Number of tube segments per pair of consecutive points = NUM_TUBE_SEGMENTS
+    //Reverse engineering the number of points in a THREE tube is not fun, and
+    //may be implementation/version dependent.
+    //Number of points drawn per tube segment =
+    //  2 (triangles) * 3 (points per triangle) * NUM_TUBE_CROSS_SECTION_POINTS
+    //Number of tube segments per pair of consecutive points =
+    //  NUM_TUBE_SEGMENTS
 
     var multiplier = 2 * 3 * NUM_TUBE_CROSS_SECTION_POINTS * NUM_TUBE_SEGMENTS;
     if (currentFrame < trajectory._intervalValues.length)
@@ -367,7 +379,8 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     }
     else
     {
-      threeMesh.geometry.setDrawRange(0, (trajectory.coordinates.length - 1) * multiplier);
+      threeMesh.geometry.setDrawRange(0,
+                            (trajectory.coordinates.length - 1) * multiplier);
     }
   }
 

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -311,9 +311,11 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
   function drawTrajectoryLineStatic(trajectory, color, radius) {
     var _trajectory = trajectory.coordinates;
     
-    var material = new THREE.MeshPhongMaterial({color: color});
-    material.matrixAutoUpdate = true;
-    material.transparent = false;
+    var material = new THREE.MeshPhongMaterial({
+      color: color,
+      matrixAutoUpdate: true,
+      transparent: false}
+    );
     
     var allPoints = [];
     for (var index = 0; index < _trajectory.length; index++) {
@@ -332,7 +334,7 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
   
   function updateStaticTrajectoryDrawRange(trajectory, currentFrame, threeMesh)
   {
-    //Blah, reverse engineering the number of points in a THREE tube is not fun, and may be implementation/version dependent.
+    //Reverse engineering the number of points in a THREE tube is not fun, and may be implementation/version dependent.
     //Number of points drawn per tube segment = 2 (triangles) * 3 (points per triangle) * NUM_TUBE_CROSS_SECTION_POINTS (number of vertices in a cross section of tube)
     //Number of tube segments per pair of consecutive points = NUM_TUBE_SEGMENTS
 

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -278,7 +278,7 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
 
     return arrow;
   }
-  
+
   /**
    * Returns a new trajectory line dynamic mesh
    */
@@ -301,7 +301,7 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     }
 
     path = new THREE.EmperorTrajectory(points);
-    
+
     // the line will contain the two vertices and the described material
     // we increase the number of points to have a smoother transition on
     // edges i. e. where the trajectory changes the direction it is going
@@ -310,7 +310,7 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
 
     return new THREE.Mesh(lineGeometry, material);
   }
-  
+
   /**
    * Disposes a trajectory line dynamic mesh
    */
@@ -324,12 +324,12 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
    */
   function drawTrajectoryLineStatic(trajectory, color, radius) {
     var _trajectory = trajectory.coordinates;
-    
+
     var material = new THREE.MeshPhongMaterial({
       color: color,
       transparent: false}
     );
-    
+
     var allPoints = [];
     for (var index = 0; index < _trajectory.length; index++) {
       allPoints.push(new THREE.Vector3(_trajectory[index].x,
@@ -337,14 +337,14 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     }
 
     var path = new THREE.EmperorTrajectory(allPoints);
-    
+
     //Tubes are straight segments, but adding vertices along them might change lighting effects
     //under certain models and lighting conditions.
-    var tubeBufferGeom = new THREE.TubeBufferGeometry(path, (allPoints.length - 1) * NUM_TUBE_SEGMENTS, radius, NUM_TUBE_CROSS_SECTION_POINTS, false)
+    var tubeBufferGeom = new THREE.TubeBufferGeometry(path, (allPoints.length - 1) * NUM_TUBE_SEGMENTS, radius, NUM_TUBE_CROSS_SECTION_POINTS, false);
 
     return new THREE.Mesh(tubeBufferGeom, material);
   }
-  
+
   /**
    * Disposes a trajectory line static mesh
    */
@@ -359,7 +359,7 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     //Number of points drawn per tube segment = 2 (triangles) * 3 (points per triangle) * NUM_TUBE_CROSS_SECTION_POINTS (number of vertices in a cross section of tube)
     //Number of tube segments per pair of consecutive points = NUM_TUBE_SEGMENTS
 
-    var multiplier = 2 * 3 * NUM_TUBE_CROSS_SECTION_POINTS * NUM_TUBE_SEGMENTS
+    var multiplier = 2 * 3 * NUM_TUBE_CROSS_SECTION_POINTS * NUM_TUBE_SEGMENTS;
     if (currentFrame < trajectory._intervalValues.length)
     {
       var intervalValue = trajectory._intervalValues[currentFrame];

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -293,7 +293,6 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
 
     material = new THREE.MeshPhongMaterial({
         color: color,
-        matrixAutoUpdate: true,
         transparent: false});
 
     for (var index = 0; index < _trajectory.length; index++) {
@@ -328,7 +327,6 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     
     var material = new THREE.MeshPhongMaterial({
       color: color,
-      matrixAutoUpdate: true,
       transparent: false}
     );
     

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -279,6 +279,9 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     return arrow;
   }
   
+  /**
+   * Returns a new trajectory line dynamic mesh
+   */
   function drawTrajectoryLineDynamic(trajectory, currentFrame, color, radius) {
     // based on the example described in:
     // https://github.com/mrdoob/three.js/wiki/Drawing-lines
@@ -288,9 +291,10 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     if (_trajectory === null || _trajectory.length == 0)
       return null;
 
-    material = new THREE.MeshPhongMaterial({color: color});
-    material.matrixAutoUpdate = true;
-    material.transparent = false;
+    material = new THREE.MeshPhongMaterial({
+        color: color,
+        matrixAutoUpdate: true,
+        transparent: false});
 
     for (var index = 0; index < _trajectory.length; index++) {
       points.push(new THREE.Vector3(_trajectory[index].x,
@@ -307,7 +311,18 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
 
     return new THREE.Mesh(lineGeometry, material);
   }
-    
+  
+  /**
+   * Disposes a trajectory line dynamic mesh
+   */
+  function disposeTrajectoryLineDynamic(mesh) {
+    mesh.geometry.dispose();
+    mesh.material.dispose();
+  }
+
+  /**
+   * Returns a new trajectory line static mesh
+   */
   function drawTrajectoryLineStatic(trajectory, color, radius) {
     var _trajectory = trajectory.coordinates;
     
@@ -332,6 +347,14 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
     return new THREE.Mesh(tubeBufferGeom, material);
   }
   
+  /**
+   * Disposes a trajectory line static mesh
+   */
+  function disposeTrajectoryLineStatic(mesh) {
+    mesh.geometry.dispose();
+    mesh.material.dispose();
+  }
+
   function updateStaticTrajectoryDrawRange(trajectory, currentFrame, threeMesh)
   {
     //Reverse engineering the number of points in a THREE tube is not fun, and may be implementation/version dependent.
@@ -464,7 +487,9 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
   return {'formatSVGLegend': formatSVGLegend, 'makeLine': makeLine,
           'makeLabel': makeLabel, 'makeArrow': makeArrow,
           'drawTrajectoryLineStatic': drawTrajectoryLineStatic,
+          'disposeTrajectoryLineStatic': disposeTrajectoryLineStatic,
           'drawTrajectoryLineDynamic': drawTrajectoryLineDynamic,
+          'disposeTrajectoryLineDynamic': disposeTrajectoryLineDynamic,
           'updateStaticTrajectoryDrawRange': updateStaticTrajectoryDrawRange,
           'makeLineCollection': makeLineCollection};
 });

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -278,32 +278,6 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
 
     return arrow;
   }
-
-  function drawTrajectoryLine(trajectory, currentFrame, color, radius) {
-    // based on the example described in:
-    // https://github.com/mrdoob/three.js/wiki/Drawing-lines
-    var material, points = [], lineGeometry, limit = 0, path;
-
-    _trajectory = trajectory.representativeCoordinatesAtIndex(currentFrame);
-
-    material = new THREE.MeshPhongMaterial({color: color});
-    material.matrixAutoUpdate = true;
-    material.transparent = false;
-
-    for (var index = 0; index < _trajectory.length; index++) {
-      points.push(new THREE.Vector3(_trajectory[index].x,
-                  _trajectory[index].y, _trajectory[index].z));
-    }
-
-    path = new THREE.EmperorTrajectory(points);
-    // the line will contain the two vertices and the described material
-    // we increase the number of points to have a smoother transition on
-    // edges i. e. where the trajectory changes the direction it is going
-    lineGeometry = new THREE.TubeGeometry(path, (points.length - 1) * NUM_TUBE_SEGMENTS, radius,
-                                          NUM_TUBE_CROSS_SECTION_POINTS, false);
-
-    return new THREE.Mesh(lineGeometry, material);
-  }
   
   function drawTrajectoryLineDynamic(trajectory, currentFrame, color, radius) {
     // based on the example described in:
@@ -487,7 +461,6 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
 
   return {'formatSVGLegend': formatSVGLegend, 'makeLine': makeLine,
           'makeLabel': makeLabel, 'makeArrow': makeArrow,
-          'drawTrajectoryLine': drawTrajectoryLine,
           'drawTrajectoryLineStatic': drawTrajectoryLineStatic,
           'drawTrajectoryLineDynamic': drawTrajectoryLineDynamic,
           'updateStaticTrajectoryDrawRange': updateStaticTrajectoryDrawRange,

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -677,8 +677,12 @@ define([
     });
 
     _.each(this.decViews, function(view) {
-      view.tubes.forEach(function(tube) {
+      view.staticTubes.forEach(function(tube) {
         scope.scene.add(tube);
+      });
+      view.dynamicTubes.forEach(function(tube) {
+        if (tube !== null)
+          scope.scene.add(tube);
       });
     });
 

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -677,10 +677,7 @@ define([
     });
 
     _.each(this.decViews, function(view) {
-      view.staticTubes.forEach(function(tube) {
-        scope.scene.add(tube);
-      });
-      view.dynamicTubes.forEach(function(tube) {
+      view.getTubes().forEach(function(tube) {
         if (tube !== null)
           scope.scene.add(tube);
       });

--- a/emperor/support_files/js/trajectory.js
+++ b/emperor/support_files/js/trajectory.js
@@ -186,7 +186,7 @@ define([
 
     return output;
   };
-  
+
   /**
    *
    * Grab only the interpolated portion of representativeCoordinatesAtIndex.
@@ -200,20 +200,20 @@ define([
   TrajectoryOfSamples.prototype.representativeInterpolatedCoordinatesAtIndex = function(idx) {
     if (idx === 0)
       return null;
-    if (this.interpolatedCoordinates.length -1 <= idx)
+    if (this.interpolatedCoordinates.length - 1 <= idx)
       return null;
-      
+
     lastStaticPoint = this.coordinates[this._intervalValues[idx]];
     interpPoint = this.interpolatedCoordinates[idx];
-    if (lastStaticPoint.x === interpPoint.x
-      && lastStaticPoint.y === interpPoint.y
-      && lastStaticPoint.z === interpPoint.z) {
+    if (lastStaticPoint.x === interpPoint.x &&
+      lastStaticPoint.y === interpPoint.y &&
+      lastStaticPoint.z === interpPoint.z) {
       return null; //Shouldn't pass on a zero length segment
     }
-      
+
     return [lastStaticPoint, interpPoint];
-  }
-  
+  };
+
   /**
    *
    * Function to interpolate a certain number of steps between two three

--- a/emperor/support_files/js/trajectory.js
+++ b/emperor/support_files/js/trajectory.js
@@ -195,9 +195,11 @@ define([
    * points.
    *
    * @return {Array[]} Array containing the representative float x, y, z
-   * coordinates needed to draw the interpolated portion of a trajectory at the given index.
+   * coordinates needed to draw the interpolated portion of a trajectory at the
+   * given index.
    */
-  TrajectoryOfSamples.prototype.representativeInterpolatedCoordinatesAtIndex = function(idx) {
+  TrajectoryOfSamples.prototype.representativeInterpolatedCoordinatesAtIndex =
+  function(idx) {
     if (idx === 0)
       return null;
     if (this.interpolatedCoordinates.length - 1 <= idx)

--- a/emperor/support_files/js/trajectory.js
+++ b/emperor/support_files/js/trajectory.js
@@ -186,7 +186,25 @@ define([
 
     return output;
   };
-
+  
+  /**
+   *
+   * Grab only the interpolated portion of representativeCoordinatesAtIndex.
+   *
+   * @param {integer} idx Value for which to determine the required number of
+   * points.
+   *
+   * @return {Array[]} Array containing the representative float x, y, z
+   * coordinates needed to draw the interpolated portion of a trajectory at the given index.
+   */
+  TrajectoryOfSamples.prototype.representativeInterpolatedCoordinatesAtIndex = function(idx) {
+    if (idx === 0)
+      return null;
+    if (this.interpolatedCoordinates.length -1 <= idx)
+      return null;
+    return [this.coordinates[this._intervalValues[idx]], this.interpolatedCoordinates[idx]];
+  }
+  
   /**
    *
    * Function to interpolate a certain number of steps between two three

--- a/emperor/support_files/js/trajectory.js
+++ b/emperor/support_files/js/trajectory.js
@@ -202,7 +202,16 @@ define([
       return null;
     if (this.interpolatedCoordinates.length -1 <= idx)
       return null;
-    return [this.coordinates[this._intervalValues[idx]], this.interpolatedCoordinates[idx]];
+      
+    lastStaticPoint = this.coordinates[this._intervalValues[idx]];
+    interpPoint = this.interpolatedCoordinates[idx];
+    if (lastStaticPoint.x === interpPoint.x
+      && lastStaticPoint.y === interpPoint.y
+      && lastStaticPoint.z === interpPoint.z) {
+      return null; //Shouldn't pass on a zero length segment
+    }
+      
+    return [lastStaticPoint, interpPoint];
   }
   
   /**

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -63,10 +63,18 @@ function DecompositionView(decomp, asPointCloud) {
    */
   this.backgroundColor = '#000000';
   /**
-   * Tube objects on screen (used for animations)
+   * Static tubes objects covering an entire trajectory.
+   * Can use setDrawRange on the underlying geometry to display
+   * just part of the trajectory.
    * @type {THREE.Mesh[]}
    */
-  this.tubes = [];
+  this.staticTubes = [];
+  /**
+   * Dynamic tubes covering the final tube segment of a trajectory
+   * Must be rebuilt each frame by the animations controller
+   * @type {THREE.Mesh[]}
+   */
+  this.dynamicTubes = [];
   /**
    * Array of THREE.Mesh objects on screen (represent samples).
    * @type {THREE.Mesh[]}

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -129,6 +129,14 @@ DecompositionView.prototype.getGeometryFactor = function() {
 };
 
 /**
+ * Retrieve a shallow copy of concatenated static and dynamic tube arrays
+ * @type {THREE.Mesh[]}
+ */
+DecompositionView.prototype.getTubes = function() {
+  return this.staticTubes.concat(this.dynamicTubes);
+};
+
+/**
  *
  * Helper method to initialize the base THREE.js objects.
  * @private

--- a/tests/javascript_tests/test_decomposition_view.js
+++ b/tests/javascript_tests/test_decomposition_view.js
@@ -82,7 +82,8 @@ requirejs([
       equal(dv.getVisibleCount(), 2, 'visibleCount set correctly');
       deepEqual(dv.visibleDimensions, [0, 1, 2],
           'visibleDimensions set correctly');
-      deepEqual(dv.tubes, [], 'tubes set correctly');
+      deepEqual(dv.staticTubes, [], 'tubes set correctly');
+      deepEqual(dv.dynamicTubes, [], 'tubes set correctly');
 
       equal(dv.axesColor, '#FFFFFF');
       equal(dv.backgroundColor, '#000000');
@@ -138,7 +139,8 @@ requirejs([
       equal(dv.getVisibleCount(), 2, 'visibleCount set correctly');
       deepEqual(dv.visibleDimensions, [0, 1],
           'visibleDimensions set correctly');
-      deepEqual(dv.tubes, [], 'tubes set correctly');
+      deepEqual(dv.staticTubes, [], 'tubes set correctly');
+      deepEqual(dv.dynamicTubes, [], 'tubes set correctly');
 
       equal(dv.axesColor, '#FFFFFF');
       equal(dv.backgroundColor, '#000000');
@@ -160,7 +162,8 @@ requirejs([
       equal(view.count, 2);
       equal(view.getVisibleCount(), 2);
       deepEqual(view.visibleDimensions, [0, 1, 2]);
-      deepEqual(view.tubes, []);
+      deepEqual(view.staticTubes, [], 'tubes set correctly');
+      deepEqual(view.dynamicTubes, [], 'tubes set correctly');
       equal(view.axesColor, '#FFFFFF');
       equal(view.backgroundColor, '#000000');
       deepEqual(view.axesOrientation, [1, 1, 1]);
@@ -199,7 +202,8 @@ requirejs([
       equal(view.count, 2);
       equal(view.getVisibleCount(), 2);
       deepEqual(view.visibleDimensions, [0, 1, 2]);
-      deepEqual(view.tubes, []);
+      deepEqual(view.staticTubes, [], 'tubes set correctly');
+      deepEqual(view.dynamicTubes, [], 'tubes set correctly');
       equal(view.axesColor, '#FFFFFF');
       equal(view.backgroundColor, '#000000');
       deepEqual(view.axesOrientation, [1, 1, 1]);

--- a/tests/javascript_tests/test_trajectory.js
+++ b/tests/javascript_tests/test_trajectory.js
@@ -366,19 +366,25 @@ requirejs(['underscore', 'trajectory'], function(_, trajectory) {
           [{'x': 0, 'y': 0, 'z': 0},
           {'x': 0.75, 'y': 0.75, 'z': 0.75}],
           'Coordinates are retrieved correctly at index 3');
-        
+
       var fullCoordinates11 = trajectory.representativeCoordinatesAtIndex(11);
       deepEqual(fullCoordinates11,
           [{'x': 0, 'y': 0, 'z': 0}, {'x': 1, 'y': 1, 'z': 1},
           {'x': -9, 'y': -9, 'z': -9}, {'x': 3, 'y': 3, 'z': 3},
           {'x': 4.25, 'y': 4.25, 'z': 4.25}],
           'Coordinates are retrieved correctly at index 11');
-         
-      var dynamicCoordinates3 = trajectory.representativeInterpolatedCoordinatesAtIndex(3);
-      var dynamicCoordinates11 = trajectory.representativeInterpolatedCoordinatesAtIndex(11);
-      
-      deepEqual(fullCoordinates3.slice(-2), dynamicCoordinates3, "Dynamic coordinates match on frame 3");
-      deepEqual(fullCoordinates11.slice(-2), dynamicCoordinates11, "Dynamic coordinates match on frame 11");
+
+      var dynamicCoordinates3 =
+        trajectory.representativeInterpolatedCoordinatesAtIndex(3);
+      var dynamicCoordinates11 =
+        trajectory.representativeInterpolatedCoordinatesAtIndex(11);
+
+      deepEqual(fullCoordinates3.slice(-2),
+                dynamicCoordinates3,
+                'Dynamic coordinates match on frame 3');
+      deepEqual(fullCoordinates11.slice(-2),
+                dynamicCoordinates11,
+                'Dynamic coordinates match on frame 11');
 
     });
 
@@ -533,7 +539,7 @@ requirejs(['underscore', 'trajectory'], function(_, trajectory) {
       equal(result, 92, 'The minimum delta is computed correctly for one ' +
           'category');
     });
-    
+
     /**
      *
      * Test trajectories with duplicate points.
@@ -541,21 +547,27 @@ requirejs(['underscore', 'trajectory'], function(_, trajectory) {
      */
     test('Test Duplicate Points In Trajectories', function() {
       var result;
-      trajectory = new TrajectoryOfSamples(['A','B','C','D'],
+      trajectory = new TrajectoryOfSamples(['A', 'B', 'C', 'D'],
           'Nonsense',
-          [1,2,3,4],
-          [{'x': 0, 'y': 0, 'z': 0}, {'x': 10, 'y': 10, 'z': 10}, {'x': 10, 'y': 10, 'z': 10}, {'x': 0, 'y': 0, 'z': 0}],
+          [1, 2, 3, 4],
+          [{'x': 0, 'y': 0, 'z': 0},
+           {'x': 10, 'y': 10, 'z': 10},
+           {'x': 10, 'y': 10, 'z': 10},
+           {'x': 0, 'y': 0, 'z': 0}],
           2,
           5);
-      
+
       for (var i = 0; i < 20; i++) {
-        var interpTubeCoords = trajectory.representativeInterpolatedCoordinatesAtIndex(i);
+        var interpTubeCoords =
+          trajectory.representativeInterpolatedCoordinatesAtIndex(i);
         if (interpTubeCoords !== null) {
           var dx = interpTubeCoords[1].x - interpTubeCoords[0].x;
           var dy = interpTubeCoords[1].y - interpTubeCoords[0].y;
           var dz = interpTubeCoords[1].z - interpTubeCoords[0].z;
           var lenSq = dx * dx + dy * dy + dz * dz;
-          notEqual(lenSq, 0, "Interpolated tube should never be built between consecutive duplicate points in a trajectory");
+          notEqual(lenSq, 0,
+            'Interpolated tube should never be built between' +
+            'consecutive duplicate points in a trajectory');
         }
       }
     });

--- a/tests/javascript_tests/test_trajectory.js
+++ b/tests/javascript_tests/test_trajectory.js
@@ -361,15 +361,24 @@ requirejs(['underscore', 'trajectory'], function(_, trajectory) {
       {'x': 6.75, 'y': 6.75, 'z': 6.75},
       {'x': 8, 'y': 8, 'z': 8}];
 
-      deepEqual(trajectory.representativeCoordinatesAtIndex(3),
+      var fullCoordinates3 = trajectory.representativeCoordinatesAtIndex(3);
+      deepEqual(fullCoordinates3,
           [{'x': 0, 'y': 0, 'z': 0},
           {'x': 0.75, 'y': 0.75, 'z': 0.75}],
           'Coordinates are retrieved correctly at index 3');
-      deepEqual(trajectory.representativeCoordinatesAtIndex(11),
+        
+      var fullCoordinates11 = trajectory.representativeCoordinatesAtIndex(11);
+      deepEqual(fullCoordinates11,
           [{'x': 0, 'y': 0, 'z': 0}, {'x': 1, 'y': 1, 'z': 1},
           {'x': -9, 'y': -9, 'z': -9}, {'x': 3, 'y': 3, 'z': 3},
           {'x': 4.25, 'y': 4.25, 'z': 4.25}],
           'Coordinates are retrieved correctly at index 11');
+         
+      var dynamicCoordinates3 = trajectory.representativeInterpolatedCoordinatesAtIndex(3);
+      var dynamicCoordinates11 = trajectory.representativeInterpolatedCoordinatesAtIndex(11);
+      
+      deepEqual(fullCoordinates3.slice(-2), dynamicCoordinates3, "Dynamic coordinates match on frame 3");
+      deepEqual(fullCoordinates11.slice(-2), dynamicCoordinates11, "Dynamic coordinates match on frame 11");
 
     });
 

--- a/tests/javascript_tests/test_trajectory.js
+++ b/tests/javascript_tests/test_trajectory.js
@@ -533,6 +533,32 @@ requirejs(['underscore', 'trajectory'], function(_, trajectory) {
       equal(result, 92, 'The minimum delta is computed correctly for one ' +
           'category');
     });
+    
+    /**
+     *
+     * Test trajectories with duplicate points.
+     *
+     */
+    test('Test Duplicate Points In Trajectories', function() {
+      var result;
+      trajectory = new TrajectoryOfSamples(['A','B','C','D'],
+          'Nonsense',
+          [1,2,3,4],
+          [{'x': 0, 'y': 0, 'z': 0}, {'x': 10, 'y': 10, 'z': 10}, {'x': 10, 'y': 10, 'z': 10}, {'x': 0, 'y': 0, 'z': 0}],
+          2,
+          5);
+      
+      for (var i = 0; i < 20; i++) {
+        var interpTubeCoords = trajectory.representativeInterpolatedCoordinatesAtIndex(i);
+        if (interpTubeCoords !== null) {
+          var dx = interpTubeCoords[1].x - interpTubeCoords[0].x;
+          var dy = interpTubeCoords[1].y - interpTubeCoords[0].y;
+          var dz = interpTubeCoords[1].z - interpTubeCoords[0].z;
+          var lenSq = dx * dx + dy * dy + dz * dz;
+          notEqual(lenSq, 0, "Interpolated tube should never be built between consecutive duplicate points in a trajectory");
+        }
+      }
+    });
 
   });
 });


### PR DESCRIPTION
I split the Tube rendering into static and dynamic portions.  Static tubes are computed once upon starting playback.  Dynamic tubes are recalculated each frame.  Static tube draw range is recalculated each frame as well.  The effect is that we draw all the animation up to a certain point, then fit a single interpolated segment onto the end of it.  This is much faster than recomputing all the tubes every frame.  

Smooth on 20000 points on my laptop.  Should check it on more hardware since it touches the webGL layer.  