### PR TITLE
Enabling filtering of missing features

### DIFF
--- a/emperor/core.py
+++ b/emperor/core.py
@@ -250,7 +250,7 @@ class Emperor(object):
             self.feature_mf = \
                 self._validate_metadata(feature_mapping_file,
                                         self.ordination.features,
-                                        ignore_missing_samples=False)
+                                        ignore_missing_samples)
 
         self._validate_ordinations()
 


### PR DESCRIPTION
Addresses #730 

Now when the ignore_missing_samples flag is enabled, features can also be enabled.

This is an easy fix - but maybe the terminology will need to be readdressed (i.e. change ignore_missing_samples -> ignore_missing).