### PR TITLE
BLD: Drop support for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
         env: NUMPY_VERSION="<1.13"
 
 before_install:
+  # run gjslint using py27
+  - sudo pip2.7 install https://github.com/google/closure-linter/archive/master.zip
   - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh && chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda2/bin:$PATH
@@ -31,8 +33,6 @@ before_install:
   - conda update --yes conda
 
 install:
-  # run gjslint using py27
-  - pip2.7 install https://github.com/google/closure-linter/archive/master.zip
   # install requests using conda to avoid a distutils error in certifi
   - conda create --yes -n travis python=$TRAVIS_PYTHON_VERSION pip numpy${NUMPY_VERSION} 'scipy>=0.17.0' matplotlib pandas flake8 pep8 jupyter coverage cython scikit-learn requests
   - source activate travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
 install:
   # gjslint only runs in py27
-  - conda create --yes -n gjslint python=2.7 pip
+  - conda create --yes -n gjslint python=2.7 pip six
   - source activate gjslint
   - pip install https://github.com/google/closure-linter/archive/master.zip
   - conda deactivate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
   # also includes 3.7 (see below)
@@ -32,17 +31,19 @@ before_install:
   - conda update --yes conda
 
 install:
+  # run gjslint using py27
+  - pip2.7 install https://github.com/google/closure-linter/archive/master.zip
   # install requests using conda to avoid a distutils error in certifi
   - conda create --yes -n travis python=$TRAVIS_PYTHON_VERSION pip numpy${NUMPY_VERSION} 'scipy>=0.17.0' matplotlib pandas flake8 pep8 jupyter coverage cython scikit-learn requests
   - source activate travis
   - conda install -c conda-forge phantomjs --yes
-  - pip install https://github.com/google/closure-linter/archive/master.zip 'sphinx<1.6' sphinx-bootstrap-theme coveralls
+  - pip 'sphinx<1.6' sphinx-bootstrap-theme coveralls
   - pip install -e '.[all]' --verbose
   - npm install -g jsdoc
 
 script:
   - flake8 emperor/*.py tests/*.py scripts/*.py setup.py
-  # we can only run gjslint using python 2.7.x
+  # we can only run gjslint using py27
   - python2.7 $(which gjslint) --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
   # we just check coverage in the latest version of NumPy
   - coverage run tests/all_tests.py; coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - conda create --yes -n travis python=$TRAVIS_PYTHON_VERSION pip numpy${NUMPY_VERSION} 'scipy>=0.17.0' matplotlib pandas flake8 pep8 jupyter coverage cython scikit-learn requests
   - source activate travis
   - conda install -c conda-forge phantomjs --yes
-  - pip 'sphinx<1.6' sphinx-bootstrap-theme coveralls
+  - pip install 'sphinx<1.6' sphinx-bootstrap-theme coveralls
   - pip install -e '.[all]' --verbose
   - npm install -g jsdoc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,11 @@ install:
 
 script:
   - flake8 emperor/*.py tests/*.py scripts/*.py setup.py
-  # we can only run gjslint using py27
-  - python2.7 $(which gjslint) --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
   # we just check coverage in the latest version of NumPy
   - coverage run tests/all_tests.py; coverage report
   - make -C doc html
+  # we can only run gjslint using py27
+  - which gjslint
+  - python2.7 $(which gjslint) --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ install:
   # gjslint only runs in py27
   - conda create --yes -n gjslint python=2.7 pip six
   - conda run -n gjslint pip install https://github.com/google/closure-linter/archive/master.zip
-  - conda deactivate
 
   # install requests using conda to avoid a distutils error in certifi
   - conda create --yes -n travis python=$TRAVIS_PYTHON_VERSION pip numpy${NUMPY_VERSION} 'scipy>=0.17.0' matplotlib pandas flake8 pep8 jupyter coverage cython scikit-learn requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,6 @@ script:
   # we can only run gjslint using py27
   - conda deactivate
   - conda activate gjslint
-  - gjslint --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
+  - conda run -n gjslint gjslint --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_install:
 install:
   # gjslint only runs in py27
   - conda create --yes -n gjslint python=2.7 pip six
-  - source activate gjslint
   - conda run -n gjslint pip install https://github.com/google/closure-linter/archive/master.zip
   - conda deactivate
 
@@ -52,8 +51,6 @@ script:
   - make -C doc html
 
   # we can only run gjslint using py27
-  - conda deactivate
-  - conda activate gjslint
   - conda run -n gjslint gjslint --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ matrix:
         env: NUMPY_VERSION="<1.13"
 
 before_install:
-  # run gjslint using py27
-  - SYSPY27=$(which python2.7)
-  - sudo pip2.7 install https://github.com/google/closure-linter/archive/master.zip
   - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh && chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda2/bin:$PATH
@@ -34,6 +31,12 @@ before_install:
   - conda update --yes conda
 
 install:
+  # gjslint only runs in py27
+  - conda create --yes -n gjslint python=2.7 pip
+  - source activate gjslint
+  - pip install https://github.com/google/closure-linter/archive/master.zip
+  - conda deactivate
+
   # install requests using conda to avoid a distutils error in certifi
   - conda create --yes -n travis python=$TRAVIS_PYTHON_VERSION pip numpy${NUMPY_VERSION} 'scipy>=0.17.0' matplotlib pandas flake8 pep8 jupyter coverage cython scikit-learn requests
   - source activate travis
@@ -47,9 +50,10 @@ script:
   # we just check coverage in the latest version of NumPy
   - coverage run tests/all_tests.py; coverage report
   - make -C doc html
+
   # we can only run gjslint using py27
-  - which gjslint
-  - echo $SYSPY27 $(which gjslint) --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
-  - $SYSPY27 $(which gjslint) --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
+  - conda deactivate
+  - conda activate gjslint
+  - gjslint --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 script:
   - flake8 emperor/*.py tests/*.py scripts/*.py setup.py
   # we just check coverage in the latest version of NumPy
-  - coverage run tests/all_tests.py; coverage report
+  - coverage run tests/all_tests.py && coverage report
   - make -C doc html
 
   # we can only run gjslint using py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   # gjslint only runs in py27
   - conda create --yes -n gjslint python=2.7 pip six
   - source activate gjslint
-  - pip install https://github.com/google/closure-linter/archive/master.zip
+  - conda run -n gjslint pip install https://github.com/google/closure-linter/archive/master.zip
   - conda deactivate
 
   # install requests using conda to avoid a distutils error in certifi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
 
 before_install:
   # run gjslint using py27
+  - which python2.7
   - sudo pip2.7 install https://github.com/google/closure-linter/archive/master.zip
   - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh && chmod +x miniconda.sh
   - ./miniconda.sh -b

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
 
 before_install:
   # run gjslint using py27
-  - which python2.7
+  - SYSPY27=$(which python2.7)
   - sudo pip2.7 install https://github.com/google/closure-linter/archive/master.zip
   - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh && chmod +x miniconda.sh
   - ./miniconda.sh -b
@@ -49,6 +49,6 @@ script:
   - make -C doc html
   # we can only run gjslint using py27
   - which gjslint
-  - python2.7 $(which gjslint) --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
+  - $SYSPY27 $(which gjslint) --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ script:
   - make -C doc html
   # we can only run gjslint using py27
   - which gjslint
+  - echo $SYSPY27 $(which gjslint) --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
   - $SYSPY27 $(which gjslint) --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ matrix:
       sudo: true
       env: NUMPY_VERSION="<1.13"
   exclude:
-      # for older python versions only test the latest versions of NumPy
-      - python: 2.7
-        env: NUMPY_VERSION="<1.13"
       - python: 3.5
         env: NUMPY_VERSION="<1.13"
 
@@ -45,8 +42,8 @@ install:
 
 script:
   - flake8 emperor/*.py tests/*.py scripts/*.py setup.py
-  # we can only run gjslint in a python 2.7.x environment
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then gjslint --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'; fi
+  # we can only run gjslint using python 2.7.x
+  - python2.7 $(which gjslint) --custom_jsdoc_tags 'module,function,constructs,alias,default' 'emperor/support_files/js/*.js' 'tests/javascript_tests/*.js'
   # we just check coverage in the latest version of NumPy
   - coverage run tests/all_tests.py; coverage report
   - make -C doc html

--- a/emperor/support_files/js/color-view-controller.js
+++ b/emperor/support_files/js/color-view-controller.js
@@ -498,6 +498,8 @@ define([
     // settings before we load from json, as they can override the JSON when set
     this.setMetadataField(json.category);
 
+    this.setEnabled(true);
+
     // if the category is null, then there's nothing to set about the state
     // of the controller
     if (json.category === null) {

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -940,6 +940,11 @@ define([
                   firstObj.geometry.attributes.opacity.getX(marker.index);
         });
 
+        // if there's no hits then finish the execution
+        if (intersects.length === 0) {
+          return;
+        }
+
         var meshIndex = intersects[0].index;
         var modelIndex = this.decViews.scatter.getModelPointIndex(meshIndex,
                                                 this.UIState['view.viewType']);
@@ -949,6 +954,12 @@ define([
         intersects = _.filter(intersects, function(marker) {
           return marker.object.visible && marker.object.material.opacity;
         });
+
+        // if there's no hits then finish the execution
+        if (intersects.length === 0) {
+          return;
+        }
+
         intersect = intersects[0].object;
       }
 

--- a/emperor/support_files/js/ui-state.js
+++ b/emperor/support_files/js/ui-state.js
@@ -1,4 +1,4 @@
-define(['three', 'underscore'], function(THREE, _) {
+define(['three'], function(THREE) {
   /**
    *
    * @class UIState
@@ -99,17 +99,22 @@ define(['three', 'underscore'], function(THREE, _) {
    * TODO: We could allow list and dictionary mutations to be part of
    * bulk events, is that a use case we think is realistic?
    */
-  UIState.prototype.setProperties = function(keyValueDict, bulkEvent = null) {
+  UIState.prototype.setProperties = function(keyValueDict, bulkEvent) {
+
+    if (bulkEvent === undefined) {
+      bulkEvent = null;
+    }
+
     var oldValueDict = {};
     for (var key in keyValueDict) {
       oldValueDict[key] = this.getProperty(key);
     }
-    for (var key in keyValueDict) {
+    for (key in keyValueDict) {
       this[key] = value;
     }
 
-    if (bulkEvent == null) {
-      for (var key in keyValueDict) {
+    if (bulkEvent === null) {
+      for (key in keyValueDict) {
         if (oldValueDict[key] !== keyValueDict[key]) {
           this.events.dispatchEvent(
             {type: key, oldVal: oldValueDict[key], newVal: keyValueDict[key]}

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -411,7 +411,7 @@ DecompositionView.prototype._fastInitParallelPlot = function()
     '  vVisible = visible;',
 
     '  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);',
-    '}'];
+    '}'].join('\n');
 
   var fragmentShader = [
     'precision mediump float;',
@@ -423,7 +423,7 @@ DecompositionView.prototype._fastInitParallelPlot = function()
     ' if (vVisible <= 0.0 || vOpacity <= 0.0)',
     '   discard;',
     ' gl_FragColor = vec4(vColor, vOpacity);',
-    '}'];
+    '}'].join('\n');
 
   var allDimensions = _.range(this.decomp.dimensions);
 

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -396,36 +396,34 @@ DecompositionView.prototype._fastInitParallelPlot = function()
 
   // We're really just drawing a bunch of line strips...
   // highly doubt shaders are necessary for this...
-  var vertexShader = `
-    attribute vec3 color;
-    attribute float opacity;
-    attribute float visible;
+  var vertexShader = [
+    'attribute vec3 color;',
+    'attribute float opacity;',
+    'attribute float visible;',
 
-    varying vec3 vColor;
-    varying float vOpacity;
-    varying float vVisible;
+    'varying vec3 vColor;',
+    'varying float vOpacity;',
+    'varying float vVisible;',
 
-    void main() {
-      vColor = color;
-      vOpacity = opacity;
-      vVisible = visible;
+    'void main() {',
+    '  vColor = color;',
+    '  vOpacity = opacity;',
+    '  vVisible = visible;',
 
-      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-    }
-    `;
+    '  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);',
+    '}'];
 
-  var fragmentShader = `
-    precision mediump float;
-    varying vec3 vColor;
-    varying float vOpacity;
-    varying float vVisible;
+  var fragmentShader = [
+    'precision mediump float;',
+    'varying vec3 vColor;',
+    'varying float vOpacity;',
+    'varying float vVisible;',
 
-    void main() {
-      if (vVisible <= 0.0 || vOpacity <= 0.0)
-        discard;
-      gl_FragColor = vec4(vColor, vOpacity);
-    }
-  `;
+    'void main() {',
+    ' if (vVisible <= 0.0 || vOpacity <= 0.0)',
+    '   discard;',
+    ' gl_FragColor = vec4(vColor, vOpacity);',
+    '}'];
 
   var allDimensions = _.range(this.decomp.dimensions);
 

--- a/emperor/support_files/templates/logic-template.html
+++ b/emperor/support_files/templates/logic-template.html
@@ -68,7 +68,6 @@ var emperorRequire = require.config({
   'shapecontroller': '{{ base_url }}/js/shape-controller',
   'axescontroller': '{{ base_url }}/js/axes-controller',
   'animationscontroller': '{{ base_url }}/js/animations-controller',
-  'viewtype-controller': '{{ base_url }}/js/viewtype-controller',
 
   /* editors */
   'shape-editor': '{{ base_url }}/js/shape-editor',

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@
 # The full license is in the file LICENSE.md, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import sys
-
 from setuptools import setup, find_packages
 
 __version__ = "1.0.0beta20-dev"
@@ -22,7 +20,6 @@ classes = """
     Topic :: Software Development :: Libraries :: Application Frameworks
     Topic :: Software Development :: User Interfaces
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -37,19 +34,11 @@ classifiers = [s.strip() for s in classes.split('\n') if s]
 with open('README.md') as f:
     long_description = f.read()
 
-skbio_2 = "scikit-bio >= 0.4.1, < 0.5.0"
-skbio_3 = "scikit-bio >= 0.4.1"
 base = ["numpy >= 1.7", "scipy >= 0.17.0", "click", "pandas",
-        skbio_2, "jinja2 >= 2.9", "future"]
+        "scikit-bio >= 0.4.1", "jinja2 >= 2.9", "future"]
 doc = ["Sphinx", "sphinx-bootstrap-theme"]
 test = ["pep8", "flake8", "nose"]
 all_deps = base + doc + test
-
-# prevent python2 from trying to install skbio >= 0.5.0 (which only works in
-# PY3K)
-if sys.version_info.major == 3:
-    base.remove(skbio_2)
-    base.append(skbio_3)
 
 setup(
     name='emperor',

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -114,10 +114,12 @@ var emperorRequire = require.config({
   'slickgrid': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/vendor/js/slick.grid.min',
   'slickformatters': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/vendor/js/slick.editors.min',
   'slickeditors': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/vendor/js/slick.formatters.min',
+  'slickdataview': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/vendor/js/slick.dataview.min',
 
   /* Emperor's objects */
   'util': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/util',
   'model': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/model',
+  'multi-model': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/multi-model',
   'view': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/view',
   'controller': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/controller',
   'draw': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/draw',
@@ -125,6 +127,7 @@ var emperorRequire = require.config({
   'shapes': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/shapes',
   'animationdirector': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/animate',
   'trajectory': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/trajectory',
+  'uistate': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/ui-state',
 
   /* controllers */
   'abcviewcontroller': 'https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/js/abc-view-controller',
@@ -165,7 +168,8 @@ var emperorRequire = require.config({
     'deps': ['blob']
   },
   'slickcore': ['jqueryui'],
-  'slickgrid': ['slickcore', 'jquery_drag', 'slickformatters', 'slickeditors']
+  'slickgrid': ['slickcore', 'jquery_drag', 'slickformatters', 'slickeditors',
+                'slickdataview']
 }
 });
 
@@ -304,10 +308,12 @@ var emperorRequire = require.config({
   'slickgrid': './some-local-path//vendor/js/slick.grid.min',
   'slickformatters': './some-local-path//vendor/js/slick.editors.min',
   'slickeditors': './some-local-path//vendor/js/slick.formatters.min',
+  'slickdataview': './some-local-path//vendor/js/slick.dataview.min',
 
   /* Emperor's objects */
   'util': './some-local-path//js/util',
   'model': './some-local-path//js/model',
+  'multi-model': './some-local-path//js/multi-model',
   'view': './some-local-path//js/view',
   'controller': './some-local-path//js/controller',
   'draw': './some-local-path//js/draw',
@@ -315,6 +321,7 @@ var emperorRequire = require.config({
   'shapes': './some-local-path//js/shapes',
   'animationdirector': './some-local-path//js/animate',
   'trajectory': './some-local-path//js/trajectory',
+  'uistate': './some-local-path//js/ui-state',
 
   /* controllers */
   'abcviewcontroller': './some-local-path//js/abc-view-controller',
@@ -355,7 +362,8 @@ var emperorRequire = require.config({
     'deps': ['blob']
   },
   'slickcore': ['jqueryui'],
-  'slickgrid': ['slickcore', 'jquery_drag', 'slickformatters', 'slickeditors']
+  'slickgrid': ['slickcore', 'jquery_drag', 'slickformatters', 'slickeditors',
+                'slickdataview']
 }
 });
 

--- a/tests/javascript_tests/index.html
+++ b/tests/javascript_tests/index.html
@@ -160,10 +160,10 @@
            'underscore', 'chroma', 'three', 'orbitcontrols', 'projector',
            'svgrenderer', 'slickgrid', 'animationdirector', 'color-editor',
            'colorviewcontroller', 'scaleviewcontroller', 'scale-editor',
-           'controller', 'draw', 'model', 'scene3d', 'trajectory', 'util',
-           'view', 'abcviewcontroller', 'viewcontroller',
-            'opacityviewcontroller', 'visibilitycontroller', 'shape-editor',
-            'shapes', 'canvastoblob', 'canvasrenderer',
+           'controller', 'draw', 'model', 'multi-model', 'scene3d',
+           'trajectory', 'util', 'view', 'abcviewcontroller', 'viewcontroller',
+           'opacityviewcontroller', 'visibilitycontroller', 'shape-editor',
+           'shapes', 'canvastoblob', 'canvasrenderer', 'uistate',
 
            'test_plottable', 'test_decomposition_model',
            'test_decomposition_view', 'test_view_controller',
@@ -182,10 +182,10 @@
                       orbitcontrols, projector, svgrenderer, slickgrid,
                       animate, coloreditor, colorviewcontroller,
                       scaleviewcontroller, scaleeditor, controller,
-                      draw, model, scene3d, trajectory, util, view,
+                      draw, model, multimodel, scene3d, trajectory, util, view,
                       abcviewcontroller, viewcontroller, opacityviewcontroller,
                       visibilitycontroller, shapeeditor, shapes, canvastoblob,
-                      canvasrenderer,
+                      canvasrenderer, uistate,
 
                       // test suites
                       test_plottable, test_decomposition_model,

--- a/tests/javascript_tests/test_color_view_controller.js
+++ b/tests/javascript_tests/test_color_view_controller.js
@@ -626,10 +626,10 @@ requirejs([
 
       controller.fromJSON(json);
 
-      // check the data is rendered
-      assert.ok(controller.$gridDiv.find(':contains(14.2)').length > 0);
-      assert.ok(controller.$gridDiv.find(':contains(StringValue)').length > 0);
-      assert.ok(controller.$gridDiv.find(':contains(14.7)').length > 0);
+      // no grid data should be rendered (continuous is set to true)
+      assert.ok(controller.$gridDiv.find(':contains(14.2)').length <= 0);
+      assert.ok(controller.$gridDiv.find(':contains(StringValue)').length <= 0);
+      assert.ok(controller.$gridDiv.find(':contains(14.7)').length <= 0);
 
       var idx = 0;
       var markers = controller.decompViewDict.scatter.markers;

--- a/tests/javascript_tests/test_color_view_controller.js
+++ b/tests/javascript_tests/test_color_view_controller.js
@@ -688,7 +688,7 @@ requirejs([
 
       equal(controller.$colormapSelect.is(':disabled'), true);
       equal(controller.$scaled.is(':disabled'), true);
-      equal(controller.$searchBar.prop('hidden'), false);
+      equal(controller.$searchBar.prop('hidden'), true);
     });
 
     /**

--- a/tests/javascript_tests/test_decomposition_view.js
+++ b/tests/javascript_tests/test_decomposition_view.js
@@ -6,7 +6,7 @@ requirejs([
     'multi-model',
     'uistate',
     'three'
-], function($, _, model, DecompositionView, MultiModel, UIState, THREE,) {
+], function($, _, model, DecompositionView, MultiModel, UIState, THREE) {
   $(document).ready(function() {
     var DecompositionModel = model.DecompositionModel;
 

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -633,9 +633,9 @@ requirejs([
      * Test the 'click' callback is resolved
      *
      */
-    test('Verifying click works', function() {
+    test('Verifying click works', function(assert) {
       // for the test to pass, two assertions should be made
-      expect(2);
+      expect(4);
 
       var renderer = new THREE.SVGRenderer({antialias: true});
       var spv = new ScenePlotView3D(this.UIState1, renderer,
@@ -644,7 +644,9 @@ requirejs([
 
       spv.on('click', function(a, b) {
         equal(a, 'Meshy McMeshface');
-        deepEqual(b, {'name': 'Meshy McMeshface'});
+        deepEqual(b.name, 'Meshy McMeshface');
+        assert.ok(b.visible);
+        deepEqual(b.material.opacity, 1);
       });
 
       var mockEvent = {
@@ -657,7 +659,15 @@ requirejs([
       };
       mockEvent.preventDefault = function() {};
 
-      var meshy = {'object': {'name': 'Meshy McMeshface'}};
+      var meshy = {'object': {
+        'name': 'Meshy McMeshface',
+        'visible': true,
+        'material': {'opacity': 1}
+      }};
+
+
+      // this should only result in one call to the click callback
+      spv._eventCallback('click', mockEvent);
       spv._raycaster.intersectObjects = function() { return [meshy]; };
       spv._eventCallback('click', mockEvent);
 
@@ -670,9 +680,9 @@ requirejs([
      * Test the 'dblclick' callback is resolved
      *
      */
-    test('Verifying double click works', function() {
+    test('Verifying double click works', function(assert) {
       // for the test to pass, two assertions should be made
-      expect(2);
+      expect(4);
 
       var renderer = new THREE.SVGRenderer({antialias: true});
       var spv = new ScenePlotView3D(this.UIState1, renderer,
@@ -681,7 +691,9 @@ requirejs([
 
       spv.on('dblclick', function(a, b) {
         equal(a, 'Meshy McMeshface');
-        deepEqual(b, {'name': 'Meshy McMeshface'});
+        deepEqual(b.name, 'Meshy McMeshface');
+        assert.ok(b.visible);
+        deepEqual(b.material.opacity, 1);
       });
 
       var mockEvent = {
@@ -694,7 +706,14 @@ requirejs([
       };
       mockEvent.preventDefault = function() {};
 
-      var meshy = {'object': {'name': 'Meshy McMeshface'}};
+      var meshy = {'object': {
+        'name': 'Meshy McMeshface',
+        'visible': true,
+        'material': {'opacity': 1}
+      }};
+
+      // this should only result in one call to the double click callback
+      spv._eventCallback('dblclick', mockEvent);
       spv._raycaster.intersectObjects = function() { return [meshy]; };
       spv._eventCallback('dblclick', mockEvent);
 


### PR DESCRIPTION
:snake: 🔥 

We need to continue to use gjslint which only runs in 2.7.x (hence the invocation in .travis.yml) but otherwise we should be good.