### PR TITLE
BUG: Fixes bug creating SVG legend

### DIFF
--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -867,7 +867,7 @@ define([
         legend = XMLS.serializeToString(this.controllers.color.$colorScale[0]);
       }
       else {
-        _.each(this.controllers.color.bodyGrid.getData(), function(element) {
+        _.each(this.controllers.color.getSlickGridDataset(), function(element) {
           names.push(element.category);
           colors.push(element.value);
         });


### PR DESCRIPTION
The code was using the old way to access grid data. I looked in the rest
of the codebase and there checked there aren't any other usages of
getData (only when necessary).

Fixes #754