### PR TITLE
Add "figure mode" button [WIP]

### DIFF
--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -266,6 +266,24 @@ define([
     });
     this.$plotSpace.append(this.$optionsButton);
 
+    /**
+     * @type {Node}
+     * jQuery object
+     */
+    this.$displayModeButton = $('<button name="dm-button">&nbsp;</button>');
+    this.$displayModeButton.css({
+      'position': 'absolute',
+      'z-index': '3',
+      'top': '5px',
+      'right': '40px'
+    }).attr('title', 'Display Mode').on('click', function(event) {
+        scope.controllers.axes.updateVisibleAxes(null, 2);
+        scope.controllers.axes._colorChanged("axes-color", "#000000");
+        scope.controllers.axes._colorChanged("background-color", "#ffffff");
+        // TODO: show circles instead of spheres; fix axis labels
+    });
+    this.$plotSpace.append(this.$displayModeButton);
+
     // default decomposition view uses the full window
     this.addSceneView();
 
@@ -273,6 +291,9 @@ define([
       // setup the jquery properties of the button
       scope.$optionsButton.button({text: false,
                                    icons: {primary: ' ui-icon-gear'}});
+
+      scope.$displayModeButton.button({text: false,
+                                   icons: {primary: ' ui-icon-star'}});
 
       scope._buildUI();
       // Hide the loading splashscreen

--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -280,7 +280,8 @@ define([
         scope.controllers.axes.updateVisibleAxes(null, 2);
         scope.controllers.axes._colorChanged("axes-color", "#000000");
         scope.controllers.axes._colorChanged("background-color", "#ffffff");
-        // TODO: show circles instead of spheres; fix axis labels
+        scope.controllers.shape.makeEverythingACircle();
+        // TODO: fix axis labels
     });
     this.$plotSpace.append(this.$displayModeButton);
 

--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -270,8 +270,8 @@ define([
      * @type {Node}
      * jQuery object
      */
-    this.$displayModeButton = $('<button name="dm-button">&nbsp;</button>');
-    this.$displayModeButton.css({
+    this.$figureModeButton = $('<button name="dm-button">&nbsp;</button>');
+    this.$figureModeButton.css({
       'position': 'absolute',
       'z-index': '3',
       'top': '5px',
@@ -283,7 +283,7 @@ define([
         scope.controllers.shape.makeEverythingACircle();
         // TODO: fix axis labels
     });
-    this.$plotSpace.append(this.$displayModeButton);
+    this.$plotSpace.append(this.$figureModeButton);
 
     // default decomposition view uses the full window
     this.addSceneView();
@@ -293,8 +293,8 @@ define([
       scope.$optionsButton.button({text: false,
                                    icons: {primary: ' ui-icon-gear'}});
 
-      scope.$displayModeButton.button({text: false,
-                                   icons: {primary: ' ui-icon-star'}});
+      scope.$figureModeButton.button({text: false,
+                                      icons: {primary: ' ui-icon-lightbulb'}});
 
       scope._buildUI();
       // Hide the loading splashscreen

--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -276,7 +276,7 @@ define([
       'z-index': '3',
       'top': '5px',
       'right': '40px'
-    }).attr('title', 'Display Mode').on('click', function(event) {
+    }).attr('title', 'Figure Mode').on('click', function(event) {
         scope.controllers.axes.updateVisibleAxes(null, 2);
         scope.controllers.axes._colorChanged("axes-color", "#000000");
         scope.controllers.axes._colorChanged("background-color", "#ffffff");

--- a/emperor/support_files/js/shape-controller.js
+++ b/emperor/support_files/js/shape-controller.js
@@ -108,7 +108,12 @@ define([
 
   /**
    *
-   * haha circle go brrrrr
+   * Analogue of _resetAttribute() above, but makes everything a circle instead
+   *
+   * NOTE: In the future, making this pay more close attention to the current
+   * shapes of each object (like how DecompositionView._buildVegaSpec() works)
+   * may be preferable. However, that may require adding more 2D shape options
+   * to Emperor.
    *
    * @extends EmperorAttributeABC
    *

--- a/emperor/support_files/js/shape-controller.js
+++ b/emperor/support_files/js/shape-controller.js
@@ -107,6 +107,25 @@ define([
   };
 
   /**
+   *
+   * haha circle go brrrrr
+   *
+   * @extends EmperorAttributeABC
+   *
+   */
+  ShapeController.prototype.makeEverythingACircle = function() {
+    EmperorAttributeABC.prototype._resetAttribute.call(this);
+    var scope = this;
+
+    _.each(this.decompViewDict, function(view) {
+      scope.setPlottableAttributes(view, 'Circle', view.decomp.plottable);
+      view.needsUpdate = true;
+    });
+  };
+
+  
+
+  /**
    * Helper function to set the shape of plottable
    *
    * @param {Object} scope The scope where the plottables exist

--- a/emperor/support_files/js/shapes.js
+++ b/emperor/support_files/js/shapes.js
@@ -3,12 +3,12 @@
 // shapes.
 define(['jquery', 'three', 'underscore'], function($, THREE, _) {
 
-  var SPHERE = 'Sphere', SQUARE = 'Square', CONE = 'Cone',
+  var SPHERE = 'Sphere', CIRCLE = 'Circle', SQUARE = 'Square', CONE = 'Cone',
       ICOSAHEDRON = 'Icosahedron', CYLINDER = 'Cylinder',
       OCTAHEDRON = 'Diamond', RING = 'Ring', STAR = 'Star';
 
-  var shapes = [SPHERE, OCTAHEDRON, CONE, CYLINDER, RING, SQUARE, ICOSAHEDRON,
-                STAR];
+  var shapes = [SPHERE, CIRCLE, OCTAHEDRON, CONE, CYLINDER, RING, SQUARE,
+                ICOSAHEDRON, STAR];
 
   /**
    *
@@ -35,6 +35,10 @@ define(['jquery', 'three', 'underscore'], function($, THREE, _) {
     switch (shapeName) {
       case SPHERE:
         return new THREE.SphereGeometry(factor, 8, 8);
+      case CIRCLE:
+        geom = new THREE.CircleGeometry(factor, 16);
+        geom.rotateX(0.3);
+        return geom;
       case SQUARE:
         geom = new THREE.PlaneGeometry(factor * 2, factor * 2, 2, 2);
         geom.rotateX(0.3);

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -1084,6 +1084,7 @@ DecompositionView.prototype._buildVegaSpec = function() {
   // Maps THREE.js geometries to vega shapes
   var getShape = {
     Sphere: 'circle',
+    Circle: 'circle',
     Diamond: 'diamond',
     Cone: 'triangle-down',
     Cylinder: 'square',

--- a/tests/javascript_tests/test_shape_controller.js
+++ b/tests/javascript_tests/test_shape_controller.js
@@ -19,8 +19,9 @@ requirejs([
     module('Shape Controller', {
       setup: function() {
         // setup function
-        this.shapesAvailable = ['Sphere', 'Diamond', 'Cone', 'Cylinder',
-                                'Ring', 'Square', 'Icosahedron', 'Star'];
+        this.shapesAvailable = ['Sphere', 'Circle', 'Diamond', 'Cone',
+                                'Cylinder', 'Ring', 'Square', 'Icosahedron',
+                                'Star'];
         this.sharedDecompositionViewDict = {};
 
         var UIState1 = new UIState();


### PR DESCRIPTION
Closes #753 and closes #604.

This PR adds a small lightbulb icon in the top-right corner of the display, directly to the left of the "More Options" button:

![image](https://user-images.githubusercontent.com/4177727/83339265-f2b9d500-a280-11ea-87f4-e8d16434a8d6.png)

On clicking this button, the plot changes to use more easily-displayable-in-a-paper settings:

![image](https://user-images.githubusercontent.com/4177727/83339272-fd746a00-a280-11ea-9738-5793c1c1e538.png)

The exact things that this button does are:

1. Make the plot 2D
2. Change the axis color to black
3. Change the background color to white
4. Change all of the shapes to circles (#604)

The first three of these things required minimal extra code (as is shown in `controller.js`, each takes up one line of code -- I attribute this to Emperor's APIs being really well designed :).

The fourth thing (making everything a circle), however, required more work -- and this is what I'm most uncertain about here.

This PR adds "Circle" as a selectable shape, and it seems to work pretty well in the JS interface -- but there are some artifacts in the exported screenshots, for example with the Jaccard moving pictures PCoA:

_In-Emperor_
![image](https://user-images.githubusercontent.com/4177727/83339759-b6d53e80-a285-11ea-8009-26a21d029802.png)

_Exported PNG_ (note the "triangle" borders within each circle, as well as the slight inconsistency of that one blue dot at the top being partially on top of orange)
![emperor (2)](https://user-images.githubusercontent.com/4177727/83339797-d10f1c80-a285-11ea-9d7f-a110178ed78b.png)

_Exported PNG (zoomed in at the top)_
![image](https://user-images.githubusercontent.com/4177727/83339823-07e53280-a286-11ea-89e4-83ce2639c6a9.png)

Anyway, I was thinking we may we want to be smarter about shapes for the 2D mode anyway --  and do something similar to how `DecompositionView._buildVegaSpec()` [has an object set up to convert 3D shapes to "close" 2D shapes](https://github.com/biocore/emperor/blob/e874f0416104449fe32fc1a50b8c517369623269/emperor/support_files/js/view.js#L1086-L1116). That might require extra work due to a need to add more 2D shapes to Emperor, so before doing that I wanted to check to see what folks would prefer (we could also conceivably not change the shapes at all, and/or leave doing that to a separate PR). So this is marked as a draft for now.

(Also, this PR should have tests, at least for things like `makeEverythingACircle()`.)