### PR TITLE
Adds callbacks to all controllers and documentation on how to use them

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,7 @@ Emperor ChangeLog
 * Add sample selection support. Users can select samples by holding shift and
   dragging the mouse. Selected samples are copied to the users' clipboard
   ([#153](https://github.com/biocore/emperor/issues/153)).
+* Add callback support for multiple grid events.
 
 ### Miscellaneous
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -53,8 +53,8 @@ clean:
 	rm -rf doc/build/jsdoc/*
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	jsdoc ../emperor/support_files/js/ -d $(BUILDDIR)/jsdoc -c jsdoc-config.json
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -34,6 +34,14 @@ Animations:
 
    tutorials/animations
 
+JavaScript Integration
+======================
+
+.. toctree::
+   :maxdepth: 2
+
+   js_integration
+
 Citing Emperor
 ==============
 

--- a/doc/source/js_integration.rst
+++ b/doc/source/js_integration.rst
@@ -1,0 +1,102 @@
+.. _js_integration:
+
+.. index:: js_integration
+
+Integrating Emperor's JavaScript API with other applications
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Emperor provides a rich API to manipulate the application live from the
+browser. The majority of this functionality is provided by attribute (Color,
+Visibility, Opacity, etc), or if needed the underlying `THREE` objects can
+be accessed as needed. For more information, the documentation for the
+`EmperorController` and other JavaScript classes can be accessed `here
+<../jsdoc/index.html>`_.
+
+
+In general, users won't need to do low-level manipulation of visual aspects but
+instead would like to subscribe to specific events and act as needed. For these
+cases, Emperor provides access to the following events:
+
+- When a sample is clicked.
+- When a sample is double-clicked.
+- When a group of samples is selected.
+- When the selected metadata category in a tab is changed.
+- When an attribute for a group of samples is changed (for example when a
+  metadata value's color or visibility is changed).
+- When a group of samples is double-clicked via a tab.
+
+
+Subscribing to Events from a 3rd Party application
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For sample clicking, double-clicking and selection three special tags are
+provided for users to insert their custom code:
+
+- `/*__click_callback*/`: This callback receives an object with the sample that
+  was clicked.
+- `/*__dblclick_callback*/`: This callback receives an object with the sample
+  that was double-clicked.
+- `/*__select_callback*/`: This callback receives a list of the selected
+  objects.
+
+The rest of the callbacks are recommended to be written and inserted
+via the `/*__custom_on_ready_code__*/`. This code is executed once all the
+controllers have finished loading and can accept subscriptions to events.
+
+The following example shows how we would subscribe to metadata category changes
+in the **color** tab, **visibility** values changing for a metadata value, and
+when a metadata value is double-clicked in the **opacity** table.
+
+.. code-block:: javascript
+
+    ec.controllers.color.addEventListener('category-changed',
+                                          function(container){
+      console.log('Name of the event', container.type);
+      console.log('Selected metadata category', container.message.category);
+
+      // this is an instance of the color controller
+      console.log('Attribute controller', container.message.controller);
+    });
+    
+    ec.controllers.visibility.addEventListener('value-changed',
+                                               function(container){
+      console.log('Name of the event', container.type);
+      console.log('Selected  category', container.message.category);
+
+      // the new visibility attribute
+      console.log('New attribute', container.message.attribute)
+
+      // the group of samples affected by the change
+      console.log('Group of samples', container.message.group)
+
+      // this is an instance of the visibility controller
+      console.log('Attribute controller', container.message.controller);
+    });
+    
+    ec.controllers.opacity.addEventListener('value-double-clicked',
+                                            function(container){
+      console.log('Name of the event', container.type);
+
+      // the attribute and name of the element that was double clicked
+      console.log('Metadata group', container.message.category);
+      console.log('Opacity value', container.message.attribute)
+
+      // the group of samples that was double-clicked
+      console.log('Group of samples', container.message.group)
+
+      // this is an instance of the opacity controller
+      console.log('Attribute controller', container.message.controller);
+    });
+
+
+And in order to insert the custom code you can use Python's string replacement
+operations:
+
+
+.. code-block:: python
+
+    viz = Emperor(...)
+
+    # custom JS - this example prints the name of the sample when that sample is
+    # clicked
+    html = str(viz).replace('/*__custom_on_ready_code__*/', 'console.log(sample)')

--- a/doc/source/js_integration.rst
+++ b/doc/source/js_integration.rst
@@ -17,13 +17,13 @@ In general, users won't need to do low-level manipulation of visual aspects but
 instead would like to subscribe to specific events and act as needed. For these
 cases, Emperor provides access to the following events:
 
-- When a sample is clicked.
-- When a sample is double-clicked.
-- When a group of samples is selected.
-- When the selected metadata category in a tab is changed.
+- When a sample is clicked (`click`).
+- When a sample is double-clicked (`dblclick`).
+- When a group of samples is selected (`select`).
+- When the selected metadata category in a tab is changed (`category-changed`).
 - When an attribute for a group of samples is changed (for example when a
-  metadata value's color or visibility is changed).
-- When a group of samples is double-clicked via a tab.
+  metadata value's color or visibility is changed) (`value-changed`).
+- When a group of samples is double-clicked via a tab (`value-double-clicked`).
 
 
 Subscribing to Events from a 3rd Party application

--- a/doc/source/js_integration.rst
+++ b/doc/source/js_integration.rst
@@ -61,7 +61,7 @@ when a metadata value is double-clicked in the **opacity** table.
     ec.controllers.visibility.addEventListener('value-changed',
                                                function(container){
       console.log('Name of the event', container.type);
-      console.log('Selected  category', container.message.category);
+      console.log('Selected category', container.message.category);
 
       // the new visibility attribute
       console.log('New attribute', container.message.attribute)

--- a/emperor/support_files/js/abc-view-controller.js
+++ b/emperor/support_files/js/abc-view-controller.js
@@ -1,7 +1,8 @@
 define([
     'jquery',
-    'underscore'
-], function($, _) {
+    'underscore',
+    'three'
+], function($, _, THREE) {
   /**
    *
    * @class EmperorViewControllerABC
@@ -22,6 +23,7 @@ define([
    *
    */
   function EmperorViewControllerABC(uiState, container, title, description) {
+    THREE.EventDispatcher.call(this);
 
     /**
      * @type {UIState}
@@ -117,6 +119,9 @@ define([
 
     return this;
   }
+  EmperorViewControllerABC.prototype = Object.create(
+      THREE.EventDispatcher.prototype);
+  EmperorViewControllerABC.prototype.constructor = THREE.EventDispatcher;
 
   /**
    * Sets whether or not elements in the tab can be modified.

--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -28,8 +28,8 @@ define([
 
   var EmperorAttributeABC = viewcontroller.EmperorAttributeABC;
 
-  TAB_ORDER = ['color', 'visibility', 'opacity', 'scale',
-               'shape', 'axes', 'animations'];
+  var TAB_ORDER = ['color', 'visibility', 'opacity', 'scale',
+                   'shape', 'axes', 'animations'];
 
   var controllerConstructors = {
       'color': ColorViewController,

--- a/emperor/support_files/js/controller.js
+++ b/emperor/support_files/js/controller.js
@@ -604,7 +604,7 @@ define([
       if (item === 'shape' && isLargeDataset)
         continue;
       scope.controllers[item] = scope.addTab(scope.sceneViews[0].decViews,
-                                           controllerConstructors[item]);
+                                             controllerConstructors[item]);
     }
 
     // We are tabifying this div, I don't know man.

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -452,7 +452,7 @@ define([
     this.bodyGrid.onCellChange.subscribe(function(e, args) {
       scope.dispatchEvent({type: 'value-changed',
                            message: {category: scope.getMetadataField(),
-                                     value: args.item.value,
+                                     attribute: args.item.value,
                                      group: args.item.plottables,
                                      controller: scope}
       });
@@ -463,12 +463,13 @@ define([
       var item = scope.bodyGrid.getDataItem(args.row);
       scope.dispatchEvent({type: 'value-double-clicked',
                            message: {category: scope.getMetadataField(),
-                                     value: item.value,
+                                     value: item.category,
+                                     attribute: item.value,
                                      group: item.plottables,
                                      controller: scope}
       });
     });
-  }
+  };
 
   /**
    * Resizes the container and the individual elements.

--- a/emperor/support_files/js/view-controller.js
+++ b/emperor/support_files/js/view-controller.js
@@ -237,6 +237,8 @@ define([
         scope.$select.chosen().change(options.categorySelectionCallback);
       }
 
+      // general events
+      scope._setupEvents();
     });
 
     return this;
@@ -434,6 +436,39 @@ define([
     // subscribe to events when a cell is changed
     this.bodyGrid.onCellChange.subscribe(options.valueUpdatedCallback);
   };
+
+  EmperorAttributeABC.prototype._setupEvents = function() {
+    var scope = this;
+
+    // dispatch an event when the category changes
+    this.$select.on('change', function() {
+      scope.dispatchEvent({type: 'category-changed',
+                           message: {category: scope.getMetadataField(),
+                                     controller: scope}
+      });
+    });
+
+    // dispatch an event when a value changes and send the plottable objects
+    this.bodyGrid.onCellChange.subscribe(function(e, args) {
+      scope.dispatchEvent({type: 'value-changed',
+                           message: {category: scope.getMetadataField(),
+                                     value: args.item.value,
+                                     group: args.item.plottables,
+                                     controller: scope}
+      });
+    });
+
+    // dispatch an event when a category is double-clicked
+    this.bodyGrid.onDblClick.subscribe(function(e, args) {
+      var item = scope.bodyGrid.getDataItem(args.row);
+      scope.dispatchEvent({type: 'value-double-clicked',
+                           message: {category: scope.getMetadataField(),
+                                     value: item.value,
+                                     group: item.plottables,
+                                     controller: scope}
+      });
+    });
+  }
 
   /**
    * Resizes the container and the individual elements.

--- a/emperor/support_files/templates/logic-template.html
+++ b/emperor/support_files/templates/logic-template.html
@@ -161,6 +161,8 @@ function($, model, EmperorController) {
       plotView.on('select', function(samples){
         /*__select_callback__*/
       });
+
+      /*__custom_on_ready_code__*/
     }
   });
 

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -232,6 +232,8 @@ function($, model, EmperorController) {
       plotView.on('select', function(samples){
         /*__select_callback__*/
       });
+
+      /*__custom_on_ready_code__*/
     }
   });
 
@@ -440,6 +442,8 @@ function($, model, EmperorController) {
       plotView.on('select', function(samples){
         /*__select_callback__*/
       });
+
+      /*__custom_on_ready_code__*/
     }
   });
 


### PR DESCRIPTION
This is useful for the ongoing integration effort with Empress. In a conversation with @antgonza he suggested it would be useful to receive callbacks to the users double-clicking a category in Emperor. I implemented this using SlickGrid's events and THREE's event dispatcher objects.

Documentation looks like this:
<img width="1576" alt="Screen Shot 2020-06-15 at 6 16 58 PM" src="https://user-images.githubusercontent.com/375307/84721093-b0f18580-af34-11ea-8bea-e5e0e2362459.png">
