### PR TITLE
Fixes an issue with parallel plots and augments the select API

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,8 @@ Emperor ChangeLog
   very slight precision differences in things like color interpolation
   ([#762](https://github.com/biocore/emperor/issues/762))
 * Fix issue failing to correctly load axes settings.
+* Fix issue where biplots and parallel plots would not work well together
+  ([#747](https://github.com/biocore/emperor/issues/747)).
 
 ### New features
 

--- a/emperor/support_files/js/draw.js
+++ b/emperor/support_files/js/draw.js
@@ -128,6 +128,30 @@ define(['underscore', 'three', 'jquery'], function(_, THREE, $) {
   };
 
   /**
+   * Dispose of underlying objects
+   */
+  EmperorArrowHelper.prototype.dispose = function() {
+    // dispose each object according to THREE's guide
+    this.label.material.map.dispose();
+    this.label.material.dispose();
+    this.label.geometry.dispose();
+
+    this.cone.material.dispose();
+    this.cone.geometry.dispose();
+
+    this.line.material.dispose();
+    this.line.geometry.dispose();
+
+    this.remove(this.label);
+    this.remove(this.cone);
+    this.remove(this.line);
+
+    this.label = null;
+    this.cone = null;
+    this.line = null;
+  };
+
+  /**
    *
    * Create a generic THREE.Line object
    *

--- a/emperor/support_files/js/sceneplotview3d.js
+++ b/emperor/support_files/js/sceneplotview3d.js
@@ -1162,7 +1162,7 @@ define([
           }
         }
 
-        scope._selectCallback(names, scope.decViews);
+        scope._selectCallback(names, scope.decViews.scatter);
       }
 
       scope.control.enabled = true;
@@ -1177,13 +1177,13 @@ define([
    * Handle selection events.
    * @private
    */
-  ScenePlotView3D.prototype._selectCallback = function(markers) {
+  ScenePlotView3D.prototype._selectCallback = function(names, view) {
     var eventType = 'select';
 
     for (var i = 0; i < this._subscribers[eventType].length; i++) {
       // keep going if one of the callbacks fails
       try {
-        this._subscribers[eventType][i](markers);
+        this._subscribers[eventType][i](names, view);
       } catch (e) {
         console.error(e);
       }

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -1116,6 +1116,10 @@ DecompositionView.prototype.toggleLabelVisibility = function() {
 DecompositionView.prototype.setEmissive = function(emissive, group) {
   group = group || this.decomp.plottable;
 
+  if (this.decomp.isArrowType()) {
+    throw new Error('Cannot set emissive attribute of arrows');
+  }
+
   var i = 0;
 
   if (this.UIState.getProperty('view.usesPointCloud') ||

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -1164,7 +1164,7 @@ DecompositionView.prototype.groupByColor = function(names) {
       r = (colors.getX(plottable.idx) * 255) << 16;
       g = (colors.getY(plottable.idx) * 255) << 8;
       b = (colors.getZ(plottable.idx) * 255) << 0;
-      return r ^ g ^ b;
+      return ('000000' + (r ^ g ^ b).toString(16)).slice(-6);
     };
   }
   else {

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -1126,7 +1126,7 @@ DecompositionView.prototype.setEmissive = function(emissive, group) {
     emissive = (emissive > 0) * 1;
 
     for (i = 0; i < group.length; i++) {
-      emissives.setX(i, emissive);
+      emissives.setX(group[i].idx, emissive);
     }
   }
   else {
@@ -1140,7 +1140,8 @@ DecompositionView.prototype.setEmissive = function(emissive, group) {
 /**
  * Group by color
  *
- * @param {Aarray} names An array of strings with the sample names.
+ * @param {Array} names An array of strings with the sample names.
+ * @returns {Object} Mapping of colors to objects.
  */
 DecompositionView.prototype.groupByColor = function(names) {
 

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -1110,7 +1110,7 @@ DecompositionView.prototype.toggleLabelVisibility = function() {
  *
  * @param {Bool} emissive Whether the object should be emissive.
  * @param {Plottable[]} group An array of plottables for which the emissive
- * attribute. If this object is not provided, all the plottables in the
+ * attribute will be set. If this object is not provided, all the plottables in the
  * view will be have the scale set.
  */
 DecompositionView.prototype.setEmissive = function(emissive, group) {

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -1120,19 +1120,21 @@ DecompositionView.prototype.setEmissive = function(emissive, group) {
 
   if (this.UIState.getProperty('view.usesPointCloud') ||
       this.UIState.getProperty('view.viewType') === 'parallel-plot') {
-    var emissives = this.markers[0].geometry.attributes.emmissive;
+    var emissives = this.markers[0].geometry.attributes.emissive;
 
     // the emissive attribute is a boolean one
     emissive = (emissive > 0) * 1;
 
+    console.log(group);
     for (i = 0; i < group.length; i++) {
       emissives.setX(group[i].idx, emissive);
     }
+    emissives.needsUpdate = true;
   }
   else {
     for (i = 0; i < group.length; i++) {
-      var material = group[i].material;
-      collection[i].material.emissive.set(color);
+      var material = this.markers[group[i].idx].material;
+      material.emissive.set(emissive);
     }
   }
 };
@@ -1141,17 +1143,17 @@ DecompositionView.prototype.setEmissive = function(emissive, group) {
  * Group by color
  *
  * @param {Array} names An array of strings with the sample names.
- * @returns {Object} Mapping of colors to objects.
+ * @return {Object} Mapping of colors to objects.
  */
 DecompositionView.prototype.groupByColor = function(names) {
 
-  var colorGroups = {}, groupping;
+  var colorGroups = {}, groupping, markers = this.markers;
   var plottables = this.decomp.getPlottableByIDs(names);
 
   // we need to retrieve colors in a very different way
   if (this.UIState['view.viewType'] === 'parallel-plot' ||
       this.UIState['view.usesPointCloud']) {
-    var colors = cloud.geometry.attributes.color;
+    var colors = this.markers[0].geometry.attributes.color;
 
     groupping = function(plottable) {
       // taken from Color.getHexString in THREE.js
@@ -1162,15 +1164,15 @@ DecompositionView.prototype.groupByColor = function(names) {
     };
   }
   else {
-    if (this.decomp.isScatterType) {
+    if (this.decomp.isScatterType()) {
       groupping = function(plottable) {
-        return plottable.material.color.getHexString();
+        return markers[plottable.idx].material.color.getHexString();
       };
     }
     else {
       // check that this getColor method works
       groupping = function(plottable) {
-        return plottable.getColor().getHexString();
+        return markers[plottable.idx].getColor().getHexString();
       };
     }
   }

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -1173,12 +1173,17 @@ DecompositionView.prototype.groupByColor = function(names) {
   if (this.UIState['view.viewType'] === 'parallel-plot' ||
       this.UIState['view.usesPointCloud']) {
     var colors = this.markers[0].geometry.attributes.color;
+    var numPoints = 1;
+
+    if (this.markers[0].isLineSegments) {
+        numPoints = (this.decomp.dimensions * 2 - 2);
+    }
 
     groupping = function(plottable) {
       // taken from Color.getHexString in THREE.js
-      r = (colors.getX(plottable.idx) * 255) << 16;
-      g = (colors.getY(plottable.idx) * 255) << 8;
-      b = (colors.getZ(plottable.idx) * 255) << 0;
+      r = (colors.getX(plottable.idx * numPoints) * 255) << 16;
+      g = (colors.getY(plottable.idx * numPoints) * 255) << 8;
+      b = (colors.getZ(plottable.idx * numPoints) * 255) << 0;
       return ('000000' + (r ^ g ^ b).toString(16)).slice(-6);
     };
   }

--- a/emperor/support_files/js/view.js
+++ b/emperor/support_files/js/view.js
@@ -1120,7 +1120,7 @@ DecompositionView.prototype.setEmissive = function(emissive, group) {
     throw new Error('Cannot set emissive attribute of arrows');
   }
 
-  var i = 0;
+  var i = 0, j = 0;
 
   if (this.UIState.getProperty('view.usesPointCloud') ||
       this.UIState.getProperty('view.viewType') === 'parallel-plot') {
@@ -1129,9 +1129,22 @@ DecompositionView.prototype.setEmissive = function(emissive, group) {
     // the emissive attribute is a boolean one
     emissive = (emissive > 0) * 1;
 
-    console.log(group);
-    for (i = 0; i < group.length; i++) {
-      emissives.setX(group[i].idx, emissive);
+    if (this.markers[0].isPoints) {
+      for (i = 0; i < group.length; i++) {
+        emissives.setX(group[i].idx, emissive);
+      }
+    }
+    else if (this.markers[0].isLineSegments) {
+      // line segments need to be repeated one per dimension
+      for (i = 0; i < group.length; i++) {
+        var numPoints = (this.decomp.dimensions * 2 - 2);
+        var startIndex = group[i].idx * numPoints;
+        var endIndex = (group[i].idx + 1) * (numPoints);
+
+        for (j = startIndex; j < endIndex; j++) {
+          emissives.setX(j, emissive);
+        }
+      }
     }
     emissives.needsUpdate = true;
   }
@@ -1141,6 +1154,8 @@ DecompositionView.prototype.setEmissive = function(emissive, group) {
       material.emissive.set(emissive);
     }
   }
+
+  this.needsUpdate = true;
 };
 
 /**

--- a/emperor/support_files/templates/logic-template.html
+++ b/emperor/support_files/templates/logic-template.html
@@ -158,7 +158,7 @@ function($, model, EmperorController) {
       plotView.on('dblclick', function(sampleName){
         /*__dblclick_callback__*/
       });
-      plotView.on('select', function(samples){
+      plotView.on('select', function(samples, view){
         /*__select_callback__*/
       });
 

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -229,7 +229,7 @@ function($, model, EmperorController) {
       plotView.on('dblclick', function(sampleName){
         /*__dblclick_callback__*/
       });
-      plotView.on('select', function(samples){
+      plotView.on('select', function(samples, view){
         /*__select_callback__*/
       });
 
@@ -439,7 +439,7 @@ function($, model, EmperorController) {
       plotView.on('dblclick', function(sampleName){
         /*__dblclick_callback__*/
       });
-      plotView.on('select', function(samples){
+      plotView.on('select', function(samples, view){
         /*__select_callback__*/
       });
 

--- a/tests/javascript_tests/test_decomposition_view.js
+++ b/tests/javascript_tests/test_decomposition_view.js
@@ -732,7 +732,7 @@ requirejs([
       UIState1.setProperty('view.usesPointCloud', false, UIState1);
       var dv = new DecompositionView(this.multiModelWithEdges,
                                      'scatter',
-                                     UIState1);
+                                     UIState1), obs;
 
       plottables = [this.decomp.plottable[1]];
 
@@ -789,6 +789,12 @@ requirejs([
       deepEqual(dv.markers[0].material.emissive.getHex(), 0x000000);
       deepEqual(dv.markers[1].material.emissive.getHex(), 0xffffff);
 
+      dv.setColor(0xf0f0f0, [this.decomp.plottable[0]]);
+      dv.setColor(0x0f0f0f, [this.decomp.plottable[1]]);
+      obs = dv.groupByColor(['PC.636', 'PC.635']);
+      console.log(obs);
+      equal(obs['f0f0f0'].length, 1);
+      equal(obs['0f0f0f'].length, 1);
     });
 
     test('Test setters for attribures (biplot)', function(assert) {
@@ -927,6 +933,15 @@ requirejs([
       dv.setEmissive(0xffffff, plottables);
       equal(observed.geometry.attributes.emissive.getX(0), 0);
       equal(observed.geometry.attributes.emissive.getX(1), 1);
+
+      obs = dv.groupByColor(['PC.636', 'PC.635']);
+      equal(obs['0000ff'].length, 1);
+
+      dv.setColor(0xf0f0f0, [this.decomp.plottable[0]]);
+      dv.setColor(0x0f0f0f, [this.decomp.plottable[1]]);
+      obs = dv.groupByColor(['PC.636', 'PC.635']);
+      equal(obs['f0f0f0'].length, 1);
+      equal(obs['0f0f0f'].length, 1);
     });
 
   });

--- a/tests/javascript_tests/test_decomposition_view.js
+++ b/tests/javascript_tests/test_decomposition_view.js
@@ -784,6 +784,11 @@ requirejs([
       deepEqual(dv.markers[0].material.opacity, 0.5);
       deepEqual(dv.markers[1].material.transparent, false);
       deepEqual(dv.markers[1].material.opacity, 1.0);
+
+      dv.setEmissive(0xffffff, plottables);
+      deepEqual(dv.markers[0].material.emissive.getHex(), 0x000000);
+      deepEqual(dv.markers[1].material.emissive.getHex(), 0xffffff);
+
     });
 
     test('Test setters for attribures (biplot)', function(assert) {
@@ -832,6 +837,12 @@ requirejs([
           dv.setScale(0.8, plottables);
         },
         Error, 'Arrow types cannot change scale');
+
+      throws(
+        function() {
+          dv.setEmissive(0x888888, plottables);
+        },
+        Error, 'Arrow types cannot change emissive value');
 
       // opacity
       dv.setOpacity(0.5);
@@ -912,6 +923,10 @@ requirejs([
       dv.setOpacity(1.0, plottables);
       equal(observed.geometry.attributes.opacity.getX(0), 0.5);
       equal(observed.geometry.attributes.opacity.getX(1), 1.0);
+
+      dv.setEmissive(0xffffff, plottables);
+      equal(observed.geometry.attributes.emissive.getX(0), 0);
+      equal(observed.geometry.attributes.emissive.getX(1), 1);
     });
 
   });

--- a/tests/javascript_tests/test_draw.js
+++ b/tests/javascript_tests/test_draw.js
@@ -160,6 +160,17 @@ requirejs(['draw', 'three'], function(draw, THREE) {
       equal(arrow.name, 'test');
     });
 
+    test('Test dispose method in arrow works', function(assert) {
+      var arrow = makeArrow([0, 0, 0], [9, 1, 1], 0x00ff00, 'test');
+      arrow.dispose();
+
+      assert.ok(arrow.line === null);
+      assert.ok(arrow.label === null);
+      assert.ok(arrow.cone === null);
+
+      equal(arrow.children.length, 0);
+    });
+
     /**
      *
      * Test that the SVG file is generated correctly.

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -739,7 +739,7 @@ requirejs([
      */
     test('Verifying select works', function(assert) {
       // for the test to pass, four assertions should be made
-      expect(2);
+      expect(3);
 
       var renderer = new THREE.SVGRenderer({antialias: true});
       var spv = new ScenePlotView3D(this.UIState1, renderer,
@@ -750,10 +750,11 @@ requirejs([
         // checks the callback gets executed
         assert.ok(true);
         assert.equal(selected.length, 2);
-        assert.ok(view.isScatterType());
+        assert.ok(view.decomp.isScatterType());
       });
 
-      spv._selectCallback(this.sharedDecompositionViewDict.scatter.markers);
+      spv._selectCallback(['PC.636', 'PC.635'],
+                          this.sharedDecompositionViewDict.scatter);
 
       // release the control back to the main page
       spv.control.dispose();

--- a/tests/javascript_tests/test_sceneplotview3d.js
+++ b/tests/javascript_tests/test_sceneplotview3d.js
@@ -746,10 +746,11 @@ requirejs([
                                     this.sharedDecompositionViewDict,
                                     this.multiModel, this.div, 0, 0, 20, 20);
 
-      spv.on('select', function(selected) {
+      spv.on('select', function(selected, view) {
         // checks the callback gets executed
         assert.ok(true);
         assert.equal(selected.length, 2);
+        assert.ok(view.isScatterType());
       });
 
       spv._selectCallback(this.sharedDecompositionViewDict.scatter.markers);


### PR DESCRIPTION
- When a user visualized biplots, they wouldn't be able to swtich to parallel plot mode without some markers being left behind. This needed a bit of refactoring of some underlying methods #747.

- Expand the selection API to return the view object (this is for better integration with Empress) - #771 .