### PR TITLE
Add new methods to render individual Emperor components

### DIFF
--- a/doc/source/js_integration.rst
+++ b/doc/source/js_integration.rst
@@ -9,7 +9,7 @@ Emperor provides a rich API to manipulate the application live from the
 browser. The majority of this functionality is provided by attribute (Color,
 Visibility, Opacity, etc), or if needed the underlying `THREE` objects can
 be accessed as needed. For more information, the documentation for the
-`EmperorController` and other JavaScript classes can be accessed `here
+``EmperorController`` and other JavaScript classes can be accessed `here
 <../jsdoc/index.html>`_.
 
 
@@ -17,35 +17,67 @@ In general, users won't need to do low-level manipulation of visual aspects but
 instead would like to subscribe to specific events and act as needed. For these
 cases, Emperor provides access to the following events:
 
-- When a sample is clicked (`click`).
-- When a sample is double-clicked (`dblclick`).
-- When a group of samples is selected (`select`).
-- When the selected metadata category in a tab is changed (`category-changed`).
+- When a sample is clicked (``click``).
+- When a sample is double-clicked (``dblclick``).
+- When a group of samples is selected (``select``).
+- When the selected metadata category in a tab is changed (``category-changed``).
 - When an attribute for a group of samples is changed (for example when a
-  metadata value's color or visibility is changed) (`value-changed`).
-- When a group of samples is double-clicked via a tab (`value-double-clicked`).
+  metadata value's color or visibility is changed) (``value-changed``).
+- When a group of samples is double-clicked via a tab (``value-double-clicked``).
+- For animations the following events are also published ``animation-started``,
+  ``animation-new-frame-started``, ``animation-ended``, ``animation-paused``,
+  and ``animation-cancelled``.
 
 
 Subscribing to Events from a 3rd Party application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For sample clicking, double-clicking and selection three special tags are
-provided for users to insert their custom code:
+Custom code can be optionally executed via the ``Emperor.js_on_ready`` attribute.
+For example to set callbacks when a sample is clicked you can insert the
+following block of code.
 
-- `/*__click_callback*/`: This callback receives an object with the sample that
-  was clicked.
-- `/*__dblclick_callback*/`: This callback receives an object with the sample
-  that was double-clicked.
-- `/*__select_callback*/`: This callback receives a list of the selected
-  objects.
+.. code-block:: python
 
-The rest of the callbacks are recommended to be written and inserted
-via the `/*__custom_on_ready_code__*/`. This code is executed once all the
-controllers have finished loading and can accept subscriptions to events.
+    # this JavaScript code is executed when the UI finishes loading
+    callback = """
+    plotView.on('click', function(sampleName){
+      console.log('One sample was clicked', sampleName);
+    });
+    """
+    # viz is an Emperor object, for example: viz = Emperor(...)
+    viz.js_on_ready = callback
 
-The following example shows how we would subscribe to metadata category changes
-in the **color** tab, **visibility** values changing for a metadata value, and
-when a metadata value is double-clicked in the **opacity** table.
+
+For convenience, this block is inserted in a closure with the following two
+objects: ``EmperorController`` (``ec``) and a ``ScenePlotView3D``
+(``plotView``). The first object orchestrates and organizes all the controllers
+available in Emperor. ``plotView`` is mainly used to render plots and interact
+with the rendered objects.
+
+``plotView`` publishes a ``click``, ``dblclick``, and a ``select`` event when a
+sample is clicked, double-clicked or when a group of samples is selected. The
+block shows how you would subscribe to the ``dblclick`` and the ``select``
+events.
+
+.. code-block:: javascript
+
+    plotView.on('dblclick', function(sampleName){
+      console.log('One sample was double-clicked', sampleName);
+    });
+    plotView.on('select', function(samples, view){
+      console.log(samples.length, 'were clicked');
+    });
+
+
+The following example shows how to use the ``EmperorController`` (``ec``) to
+subscribe to the following events:
+
+- When a metadata category changes in the **color** tab.
+
+- When a value changes in the **visibility** tab.
+
+- When a metadata value is double-clicked in the **opacity** tab.
+
 
 .. code-block:: javascript
 
@@ -87,16 +119,3 @@ when a metadata value is double-clicked in the **opacity** table.
       // this is an instance of the opacity controller
       console.log('Attribute controller', container.message.controller);
     });
-
-
-And in order to insert the custom code you can use Python's string replacement
-operations:
-
-
-.. code-block:: python
-
-    viz = Emperor(...)
-
-    # custom JS - this example prints the name of the sample when that sample is
-    # clicked
-    html = str(viz).replace('/*__custom_on_ready_code__*/', 'console.log(sample)')

--- a/doc/source/js_integration.rst
+++ b/doc/source/js_integration.rst
@@ -65,7 +65,7 @@ events.
       console.log('One sample was double-clicked', sampleName);
     });
     plotView.on('select', function(samples, view){
-      console.log(samples.length, 'were clicked');
+      console.log(samples.length, 'samples were selected');
     });
 
 

--- a/emperor/core.py
+++ b/emperor/core.py
@@ -533,19 +533,57 @@ class Emperor(object):
         return data
 
     def render_base_dependencies(self):
+        """Render Emperor's Base dependencies
+
+        Returns
+        -------
+        str
+            A string with the base dependencies (require.js and jQuery).
+        """
         template = self._environment.get_template(BASE_DEPENDENCIES_PATH)
         return template.render(base_url=self.base_url)
 
     def render_style(self):
+        """Render Emperor's CSS
+
+        Returns
+        -------
+        str
+            A string with the CSS.
+        """
         template = self._environment.get_template(STYLE_PATH)
         return template.render(base_url=self.base_url)
 
     def render_html(self, plot_id):
+        """Render Emperor's HTML container
+
+        Parameters
+        ----------
+        plot_id : str
+            The name for Emperor's div.
+
+        Returns
+        -------
+        str
+            A string with the main container where Emperor will instantiate.
+        """
         template = self._environment.get_template(HTML_CONTAINER_PATH)
         return template.render(base_url=self.base_url, plot_id=plot_id,
                                width=self.width, height=self.height)
 
     def render_js(self, plot_id):
+        """Render Emperor's JavaScript code
+
+        Parameters
+        ----------
+        plot_id : str
+            The name for Emperor's div.
+
+        Returns
+        -------
+        str
+            A string with Emperor's main JavaScript code.
+        """
         data = self._to_dict(self._process_data(self.custom_axes,
                                                 self.jackknifing_method))
 

--- a/emperor/core.py
+++ b/emperor/core.py
@@ -24,7 +24,7 @@ Classes
 from __future__ import division
 
 from copy import deepcopy
-from os.path import join, basename
+from os.path import join
 from distutils.dir_util import copy_tree
 import warnings
 import numpy as np

--- a/emperor/support_files/templates/base-dependencies.html
+++ b/emperor/support_files/templates/base-dependencies.html
@@ -1,0 +1,3 @@
+<!-- core dependencies that are otherwise included via the jupyter notebook -->
+<script src="{{ base_url }}/vendor/js/require-2.1.22.min.js"></script>
+<script src="{{ base_url }}/vendor/js/jquery-2.1.4.min.js"></script>

--- a/emperor/support_files/templates/html-container-template.html
+++ b/emperor/support_files/templates/html-container-template.html
@@ -1,0 +1,4 @@
+<div id='{{ plot_id }}' style="position: relative; width:{{ width }}; height:{{ height }};">
+  <div class='loading' style="position: absolute;top: 50%;left: 50%;margin-left: -229px; margin-top: -59px; z-index: 10000;height:118px;width:458px;padding:0px"><img src='{{ base_url }}/img/emperor.png' alt='Emperor resources missing. Expected them to be found in {{ base_url }}'></div>
+</div>
+</div>

--- a/emperor/support_files/templates/jupyter-template.html
+++ b/emperor/support_files/templates/jupyter-template.html
@@ -1,3 +1,4 @@
 {# Load templates dynamically, so we can figure out the path on the fly #}
 {% include style_template_path %}
+{% include html_container_path %}
 {% include logic_template_path %}

--- a/emperor/support_files/templates/jupyter-template.html
+++ b/emperor/support_files/templates/jupyter-template.html
@@ -1,4 +1,6 @@
 {# Load templates dynamically, so we can figure out the path on the fly #}
 {% include style_template_path %}
 {% include html_container_path %}
+<script type="text/javascript">
 {% include logic_template_path %}
+</script>

--- a/emperor/support_files/templates/logic-template.html
+++ b/emperor/support_files/templates/logic-template.html
@@ -1,4 +1,3 @@
-<script type="text/javascript">
 // When running in the Jupyter notebook we've encountered version conflicts
 // with some dependencies. So instead of polluting the global require context,
 // we define a new context.
@@ -153,4 +152,3 @@ function($, model, EmperorController) {
   });
 
 }); // END REQUIRE.JS block
-</script>

--- a/emperor/support_files/templates/logic-template.html
+++ b/emperor/support_files/templates/logic-template.html
@@ -1,8 +1,3 @@
-<div id='{{ plot_id }}' style="position: relative; width:{{ width }}; height:{{ height }};">
-  <div class='loading' style="position: absolute;top: 50%;left: 50%;margin-left: -229px; margin-top: -59px; z-index: 10000;height:118px;width:458px;padding:0px"><img src='{{ base_url }}/img/emperor.png' alt='Emperor resources missing. Expected them to be found in {{ base_url }}'></div>
-</div>
-</div>
-
 <script type="text/javascript">
 // When running in the Jupyter notebook we've encountered version conflicts
 // with some dependencies. So instead of polluting the global require context,
@@ -152,17 +147,8 @@ function($, model, EmperorController) {
 
       // sets up generic callbacks for 3rd party consumers
       var plotView = ec.sceneViews[0];
-      plotView.on('click', function(sampleName){
-        /*__click_callback__*/
-      });
-      plotView.on('dblclick', function(sampleName){
-        /*__dblclick_callback__*/
-      });
-      plotView.on('select', function(samples, view){
-        /*__select_callback__*/
-      });
-
       /*__custom_on_ready_code__*/
+      {{ js_on_ready }}
     }
   });
 

--- a/emperor/support_files/templates/standalone-template.html
+++ b/emperor/support_files/templates/standalone-template.html
@@ -2,9 +2,7 @@
 <html lang="en">
   <head>
     <title>Emperor</title>
-    <!-- core dependencies that are otherwise included via the jupyter notebook -->
-    <script src="{{ base_url }}/vendor/js/require-2.1.22.min.js"></script>
-    <script src="{{ base_url }}/vendor/js/jquery-2.1.4.min.js"></script>
+    {% include base_dependencies_path %}
     <meta charset="utf-8">
 
     {% include style_template_path %}
@@ -23,6 +21,7 @@
     </style>
   </head>
   <body>
+    {% include html_container_path %}
     {% include logic_template_path %}
   </body>
 </html>

--- a/emperor/support_files/templates/standalone-template.html
+++ b/emperor/support_files/templates/standalone-template.html
@@ -22,6 +22,8 @@
   </head>
   <body>
     {% include html_container_path %}
+    <script type="text/javascript">
     {% include logic_template_path %}
+    </script>
   </body>
 </html>

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -274,7 +274,7 @@ if ($("#emperor-css").length == 0){{
 </div>
 </div>
     <script type="text/javascript">
-// When running in the Jupyter notebook we've encountered version conflicts
+    // When running in the Jupyter notebook we've encountered version conflicts
 // with some dependencies. So instead of polluting the global require context,
 // we define a new context.
 var emperorRequire = require.config({
@@ -428,7 +428,7 @@ function($, model, EmperorController) {
   });
 
 }); // END REQUIRE.JS block
-</script>
+    </script>
   </body>
 </html>"""
 

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -606,7 +606,7 @@ function($, model, EmperorController) {
       // sets up generic callbacks for 3rd party consumers
       var plotView = ec.sceneViews[0];
       /*__custom_on_ready_code__*/
-      
+      console.log('Hello from the other side');
     }
   });
 

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -432,6 +432,186 @@ function($, model, EmperorController) {
   </body>
 </html>"""
 
+STYLE_STRING = """<script type="text/javascript">
+
+if ($("#emperor-css").length == 0){{
+    $("head").append([
+
+        '<link id="emperor-css" rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/css/emperor.css">',
+        '<link rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/vendor/css/jquery-ui.min.css">',
+        '<link rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/vendor/css/slick.grid.min.css">',
+        '<link rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/vendor/css/spectrum.min.css">',
+        '<link rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/vendor/css/chosen.min.css">',
+        '<link rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/vendor/css/jquery.contextMenu.min.css">'
+    ]);
+}}
+</script>
+"""
+
+DIV_STRING = """<div id='emperor-notebook-0x9cb72f54' style="position: relative; width:100%; height:500px;">
+  <div class='loading' style="position: absolute;top: 50%;left: 50%;margin-left: -229px; margin-top: -59px; z-index: 10000;height:118px;width:458px;padding:0px"><img src='/nbextensions/emperor/support_files/img/emperor.png' alt='Emperor resources missing. Expected them to be found in /nbextensions/emperor/support_files'></div>
+</div>
+</div>"""
+
+DEPS_STRING = """<!-- core dependencies that are otherwise included via the jupyter notebook -->
+<script src="/nbextensions/emperor/support_files/vendor/js/require-2.1.22.min.js"></script>
+<script src="/nbextensions/emperor/support_files/vendor/js/jquery-2.1.4.min.js"></script>"""
+
+JS_STRING = """// When running in the Jupyter notebook we've encountered version conflicts
+// with some dependencies. So instead of polluting the global require context,
+// we define a new context.
+var emperorRequire = require.config({
+'context': 'emperor',
+// the left side is the module name, and the right side is the path
+// relative to the baseUrl attribute, do NOT include the .js extension
+'paths': {
+  /* jQuery */
+  'jquery': '/nbextensions/emperor/support_files/vendor/js/jquery-2.1.4.min',
+  'jqueryui': '/nbextensions/emperor/support_files/vendor/js/jquery-ui.min',
+  'jquery_drag': '/nbextensions/emperor/support_files/vendor/js/jquery.event.drag-2.2.min',
+
+  /* jQuery plugins */
+  'chosen': '/nbextensions/emperor/support_files/vendor/js/chosen.jquery.min',
+  'spectrum': '/nbextensions/emperor/support_files/vendor/js/spectrum.min',
+  'position': '/nbextensions/emperor/support_files/vendor/js/jquery.ui.position.min',
+  'contextmenu': '/nbextensions/emperor/support_files/vendor/js/jquery.contextMenu.min',
+
+  /* other libraries */
+  'underscore': '/nbextensions/emperor/support_files/vendor/js/underscore-min',
+  'chroma': '/nbextensions/emperor/support_files/vendor/js/chroma.min',
+  'filesaver': '/nbextensions/emperor/support_files/vendor/js/FileSaver.min',
+  'blob': '/nbextensions/emperor/support_files/vendor/js/Blob',
+  'canvastoblob': '/nbextensions/emperor/support_files/vendor/js/canvas-toBlob',
+  'd3': '/nbextensions/emperor/support_files/vendor/js/d3.min',
+
+  /* THREE.js and plugins */
+  'three': '/nbextensions/emperor/support_files/vendor/js/three.min',
+  'orbitcontrols': '/nbextensions/emperor/support_files/vendor/js/three.js-plugins/OrbitControls',
+  'projector': '/nbextensions/emperor/support_files/vendor/js/three.js-plugins/Projector',
+  'svgrenderer': '/nbextensions/emperor/support_files/vendor/js/three.js-plugins/SVGRenderer',
+  'canvasrenderer': '/nbextensions/emperor/support_files/vendor/js/three.js-plugins/CanvasRenderer',
+  'selectionbox': '/nbextensions/emperor/support_files/vendor/js/three.js-plugins/SelectionBox',
+  'selectionhelper': '/nbextensions/emperor/support_files/vendor/js/three.js-plugins/SelectionHelper',
+
+  /* SlickGrid */
+  'slickcore': '/nbextensions/emperor/support_files/vendor/js/slick.core.min',
+  'slickgrid': '/nbextensions/emperor/support_files/vendor/js/slick.grid.min',
+  'slickformatters': '/nbextensions/emperor/support_files/vendor/js/slick.editors.min',
+  'slickeditors': '/nbextensions/emperor/support_files/vendor/js/slick.formatters.min',
+  'slickdataview': '/nbextensions/emperor/support_files/vendor/js/slick.dataview.min',
+
+  /* Emperor's objects */
+  'util': '/nbextensions/emperor/support_files/js/util',
+  'model': '/nbextensions/emperor/support_files/js/model',
+  'multi-model': '/nbextensions/emperor/support_files/js/multi-model',
+  'view': '/nbextensions/emperor/support_files/js/view',
+  'controller': '/nbextensions/emperor/support_files/js/controller',
+  'draw': '/nbextensions/emperor/support_files/js/draw',
+  'scene3d': '/nbextensions/emperor/support_files/js/sceneplotview3d',
+  'shapes': '/nbextensions/emperor/support_files/js/shapes',
+  'animationdirector': '/nbextensions/emperor/support_files/js/animate',
+  'trajectory': '/nbextensions/emperor/support_files/js/trajectory',
+  'uistate': '/nbextensions/emperor/support_files/js/ui-state',
+
+  /* controllers */
+  'abcviewcontroller': '/nbextensions/emperor/support_files/js/abc-view-controller',
+  'viewcontroller': '/nbextensions/emperor/support_files/js/view-controller',
+  'colorviewcontroller': '/nbextensions/emperor/support_files/js/color-view-controller',
+  'visibilitycontroller': '/nbextensions/emperor/support_files/js/visibility-controller',
+  'opacityviewcontroller': '/nbextensions/emperor/support_files/js/opacity-view-controller',
+  'scaleviewcontroller': '/nbextensions/emperor/support_files/js/scale-view-controller',
+  'shapecontroller': '/nbextensions/emperor/support_files/js/shape-controller',
+  'axescontroller': '/nbextensions/emperor/support_files/js/axes-controller',
+  'animationscontroller': '/nbextensions/emperor/support_files/js/animations-controller',
+
+  /* editors */
+  'shape-editor': '/nbextensions/emperor/support_files/js/shape-editor',
+  'color-editor': '/nbextensions/emperor/support_files/js/color-editor',
+  'scale-editor': '/nbextensions/emperor/support_files/js/scale-editor'
+
+},
+/*
+   Libraries that are not AMD compatible need shim to declare their
+   dependencies.
+ */
+'shim': {
+  'jquery_drag': {
+    'deps': ['jquery', 'jqueryui']
+  },
+  'chosen': {
+    'deps': ['jquery'],
+    'exports': 'jQuery.fn.chosen'
+  },
+  'contextmenu' : {
+    'deps': ['jquery', 'jqueryui', 'position']
+  },
+  'filesaver' : {
+    'deps': ['blob']
+  },
+  'canvastoblob' : {
+    'deps': ['blob']
+  },
+  'slickcore': ['jqueryui'],
+  'slickgrid': ['slickcore', 'jquery_drag', 'slickformatters', 'slickeditors',
+                'slickdataview']
+}
+});
+
+emperorRequire(
+["jquery", "model", "controller"],
+function($, model, EmperorController) {
+  var DecompositionModel = model.DecompositionModel;
+
+  var div = $('#emperor-notebook-0x9cb72f54');
+
+  var data = {"plot": {"decomposition": {"axes_names": [0, 1, 2, 3, 4], "ci": null, "coordinates": [[-0.651995810831719, -0.3417784983371589, 0.15713116241738878, -0.15964022322388774, 0.41511600449567154], [-0.5603276951316744, 0.10857735915373172, -0.32567898978232684, 0.3750137797216106, -0.583487828830988], [0.5394835270542403, -0.3068324227225251, -0.6770043110217822, 0.203820501907719, 0.1044335488558445], [0.09964194790906594, -0.03293232371368659, 0.14978636968698092, -0.8160388524355932, -0.301343079001781], [0.661089243947507, -0.014176279685000464, 0.05537095913733857, -0.11036487613740434, -0.3456924105084198], [0.5490376828031979, 0.32957520954888647, 0.7612242145083941, 0.4322721667939822, 0.04825249860931067], [0.40202458647314415, -0.4576554852461752, -0.0728438902229666, 0.04670222577076932, 0.36567512814466946], [-0.21532604614952783, 1.0, -0.31976501999316115, -0.13561208920603846, 0.35686551552017187], [-0.8236274360749414, -0.2847775589983077, 0.27177950526966277, 0.16384736680860681, -0.05981937728235736]], "edges": [], "percents_explained": [26.6887048633, 16.256370402199998, 13.775412916099999, 11.217215823, 10.024774995000001], "sample_ids": ["PC.636", "PC.635", "PC.356", "PC.481", "PC.354", "PC.593", "PC.355", "PC.607", "PC.634"]}, "metadata": [["PC.636", "Fast", "20080116", "Fasting_mouse_I.D._636"], ["PC.635", "Fast", "20080116", "Fasting_mouse_I.D._635"], ["PC.356", "Control", "20061126", "Control_mouse_I.D._356"], ["PC.481", "Control", "20070314", "Control_mouse_I.D._481"], ["PC.354", "Control", "20061218", "Ctrol_mouse_I.D._354"], ["PC.593", "Control", "20071210", "Control_mouse_I.D._593"], ["PC.355", "Control", "20061218", "Control_mouse_I.D._355"], ["PC.607", "Fast", "20071112", "Fasting_mouse_I.D._607"], ["PC.634", "Fast", "20080116", "Fasting_mouse_I.D._634"]], "metadata_headers": ["SampleID", "Treatment", "DOB", "Description"], "settings": {}, "type": "scatter"}};
+
+  var plot, biplot = null, ec;
+
+  function init() {
+    // Initialize the DecompositionModel for the scatter plot, and optionally
+    // add one for the biplot arrows
+    plot = new DecompositionModel(data.plot.decomposition,
+                                  data.plot.metadata_headers,
+                                  data.plot.metadata,
+                                  data.plot.type);
+
+    if (data.biplot) {
+      biplot = new DecompositionModel(data.biplot.decomposition,
+                                      data.biplot.metadata_headers,
+                                      data.biplot.metadata,
+                                      data.biplot.type);
+    }
+
+    ec = new EmperorController(plot, biplot, "emperor-notebook-0x9cb72f54");
+  }
+
+  function animate() {
+    requestAnimationFrame(animate);
+    ec.render();
+  }
+  $(window).resize(function() {
+    ec.resize(div.innerWidth(), div.innerHeight());
+  });
+
+  $(function(){
+    init();
+    animate();
+
+    ec.ready = function () {
+      // any other code that needs to be executed when emperor is loaded should
+      // go here
+      ec.loadConfig(data.plot.settings);
+
+      // sets up generic callbacks for 3rd party consumers
+      var plotView = ec.sceneViews[0];
+      /*__custom_on_ready_code__*/
+      
+    }
+  });
+
+}); // END REQUIRE.JS block"""
+
 MAP_PANDAS = """#SampleID	cat_a	cat_b	cat_c	num_1	num_2	num_3	num_4
 s1	foo	a	o	21	18	75	51
 s2	foo	b	p	3	42	44	36

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -73,7 +73,6 @@ if ($("#emperor-css").length == 0){{
   <div class='loading' style="position: absolute;top: 50%;left: 50%;margin-left: -229px; margin-top: -59px; z-index: 10000;height:118px;width:458px;padding:0px"><img src='https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/img/emperor.png' alt='Emperor resources missing. Expected them to be found in https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files'></div>
 </div>
 </div>
-
 <script type="text/javascript">
 // When running in the Jupyter notebook we've encountered version conflicts
 // with some dependencies. So instead of polluting the global require context,
@@ -223,17 +222,8 @@ function($, model, EmperorController) {
 
       // sets up generic callbacks for 3rd party consumers
       var plotView = ec.sceneViews[0];
-      plotView.on('click', function(sampleName){
-        /*__click_callback__*/
-      });
-      plotView.on('dblclick', function(sampleName){
-        /*__dblclick_callback__*/
-      });
-      plotView.on('select', function(samples, view){
-        /*__select_callback__*/
-      });
-
       /*__custom_on_ready_code__*/
+      
     }
   });
 
@@ -245,8 +235,8 @@ STANDALONE_HTML_STRING = """<!DOCTYPE html>
   <head>
     <title>Emperor</title>
     <!-- core dependencies that are otherwise included via the jupyter notebook -->
-    <script src="./some-local-path//vendor/js/require-2.1.22.min.js"></script>
-    <script src="./some-local-path//vendor/js/jquery-2.1.4.min.js"></script>
+<script src="./some-local-path//vendor/js/require-2.1.22.min.js"></script>
+<script src="./some-local-path//vendor/js/jquery-2.1.4.min.js"></script>
     <meta charset="utf-8">
 
     <script type="text/javascript">
@@ -283,8 +273,7 @@ if ($("#emperor-css").length == 0){{
   <div class='loading' style="position: absolute;top: 50%;left: 50%;margin-left: -229px; margin-top: -59px; z-index: 10000;height:118px;width:458px;padding:0px"><img src='./some-local-path//img/emperor.png' alt='Emperor resources missing. Expected them to be found in ./some-local-path/'></div>
 </div>
 </div>
-
-<script type="text/javascript">
+    <script type="text/javascript">
 // When running in the Jupyter notebook we've encountered version conflicts
 // with some dependencies. So instead of polluting the global require context,
 // we define a new context.
@@ -433,17 +422,8 @@ function($, model, EmperorController) {
 
       // sets up generic callbacks for 3rd party consumers
       var plotView = ec.sceneViews[0];
-      plotView.on('click', function(sampleName){
-        /*__click_callback__*/
-      });
-      plotView.on('dblclick', function(sampleName){
-        /*__dblclick_callback__*/
-      });
-      plotView.on('select', function(samples, view){
-        /*__select_callback__*/
-      });
-
       /*__custom_on_ready_code__*/
+      
     }
   });
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -358,11 +358,6 @@ class TopLevelTests(TestCase):
         emp = Emperor(self.ord_res, self.mf, remote=self.url)
 
         obs = str(emp)
-
-        try:
-            self.assertItemsEqual(tcs.HTML_STRING.split('\n'), obs.split('\n'))
-        except AttributeError:
-            self.assertCountEqual(tcs.HTML_STRING.split('\n'), obs.split('\n'))
         self.assertEqual(tcs.HTML_STRING, obs)
 
     def test_formatting_standalone(self):
@@ -373,12 +368,6 @@ class TopLevelTests(TestCase):
 
         obs = emp.make_emperor(standalone=True)
 
-        try:
-            self.assertItemsEqual(tcs.STANDALONE_HTML_STRING.split('\n'),
-                                  obs.split('\n'))
-        except AttributeError:
-            self.assertCountEqual(tcs.STANDALONE_HTML_STRING.split('\n'),
-                                  obs.split('\n'))
         self.assertEqual(tcs.STANDALONE_HTML_STRING, obs)
 
     def test_remote_url(self):
@@ -393,11 +382,6 @@ class TopLevelTests(TestCase):
         self.mf.index.name = None
         emp = Emperor(self.ord_res, self.mf, remote=self.url)
         obs = str(emp)
-
-        try:
-            self.assertItemsEqual(tcs.HTML_STRING.split('\n'), obs.split('\n'))
-        except AttributeError:
-            self.assertCountEqual(tcs.HTML_STRING.split('\n'), obs.split('\n'))
 
         self.assertEqual(tcs.HTML_STRING, obs)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -347,6 +347,26 @@ class TopLevelTests(TestCase):
         self.assertTrue(isinstance(obs, Template))
         self.assertTrue(obs.filename.endswith('/jupyter-template.html'))
 
+    def test_render_style(self):
+        emp = Emperor(self.ord_res, self.mf, remote=False)
+        obs = emp.render_style()
+        self.assertEqual(tcs.STYLE_STRING, obs)
+
+    def test_render_html(self):
+        emp = Emperor(self.ord_res, self.mf, remote=False)
+        obs = emp.render_html('emperor-notebook-0x9cb72f54')
+        self.assertEqual(tcs.DIV_STRING, obs)
+
+    def test_render_base_dependencies(self):
+        emp = Emperor(self.ord_res, self.mf, remote=False)
+        obs = emp.render_base_dependencies()
+        self.assertEqual(tcs.DEPS_STRING, obs)
+
+    def test_render_js(self):
+        emp = Emperor(self.ord_res, self.mf, remote=False)
+        obs = emp.render_js('emperor-notebook-0x9cb72f54')
+        self.assertEqual(tcs.JS_STRING, obs)
+
     def test_get_template_standalone(self):
         emp = Emperor(self.ord_res, self.mf, remote=False)
         obs = emp._get_template(True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -364,6 +364,7 @@ class TopLevelTests(TestCase):
 
     def test_render_js(self):
         emp = Emperor(self.ord_res, self.mf, remote=False)
+        emp.js_on_ready = "console.log('Hello from the other side');"
         obs = emp.render_js('emperor-notebook-0x9cb72f54')
         self.assertEqual(tcs.JS_STRING, obs)
 


### PR DESCRIPTION
Adding 4 new methods that will make integration with Empress much more straightforward. Before we were stripping the formatted HTML based on line numbers. Now CSS, HTML and JS blocks can be individually rendered via dedicated methods. In addition, custom code can be added via the `js_on_ready` attribute.

I updated the documentation to reflect these changes.

Fixes #777