### PR TITLE
ENH: Add Toggle Visible button to Visibility tab

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@ Emperor ChangeLog
 
 ### New Features
 
+* Add `Toggle Visible` button to `Visibility` tab.
+
 ### Miscellaneous
 
 * Pin Sphinx version to be less than 4.0.

--- a/emperor/support_files/js/visibility-controller.js
+++ b/emperor/support_files/js/visibility-controller.js
@@ -68,6 +68,22 @@ define([
 
     EmperorAttributeABC.call(this, uiState, container, title, helpmenu,
         decompViewDict, options);
+
+    this.$applyAll = $("<input type='button' value='Toggle Visible'>"
+    ).css({
+      'margin': '0 auto',
+      'display': 'block'
+    });
+    this.$header.append(this.$applyAll);
+
+    $(function() {
+      scope.$applyAll.hide();
+      scope.$applyAll.on('click', function() {
+        scope.toggleVisibility();
+      });
+    });
+
+
     return this;
   }
   VisibilityController.prototype = Object.create(EmperorAttributeABC.prototype);
@@ -101,6 +117,44 @@ define([
       function(scope, visible, group) {
     scope.setVisibility(visible, group);
   };
+
+  /**
+   * Sets whether or not elements in the tab can be modified.
+   *
+   * @param {Boolean} trulse option to enable elements.
+   */
+  VisibilityController.prototype.setEnabled = function(trulse) {
+    EmperorAttributeABC.prototype.setEnabled.call(this, trulse);
+
+    // prevent errors when this method is called before the element exists
+    if (this.$applyAll) {
+      if (trulse) {
+        this.$applyAll.show();
+      }
+      else {
+        this.$applyAll.hide();
+      }
+    }
+  };
+
+  /**
+   * Toggle visible objects
+   */
+  VisibilityController.prototype.toggleVisibility = function() {
+    var view = this.getView();
+
+    var groups = this.getSlickGridDataset();
+    _.each(groups, function(group) {
+
+      // toggle the value in the data container and update the view
+      group.value = Boolean(true ^ group.value);
+      view.setVisibility(group.value, group.plottables);
+    });
+
+    // lastly, update the grid table
+    this.setSlickGridDataset(groups);
+  };
+
 
   return VisibilityController;
 });

--- a/tests/javascript_tests/test_visibility_controller.js
+++ b/tests/javascript_tests/test_visibility_controller.js
@@ -107,6 +107,39 @@ requirejs([
       equal(controller.getMetadataField(), null);
     });
 
+    test('Testing toggleVisibility', function(assert) {
+      var container = $('<div id="does-not-exist" style="height:11px; ' +
+                        'width:12px"></div>');
+      var controller = new VisibilityController(new UIState(), container,
+          this.sharedDecompositionViewDict);
+      controller.setMetadataField('Treatment');
+
+      // trun everything off
+      controller.toggleVisibility();
+      equal(controller.decompViewDict.scatter.markers[0].visible, false);
+      equal(controller.decompViewDict.scatter.markers[1].visible, false);
+
+      var groupVisibility = controller.getSlickGridDataset();
+      equal(groupVisibility[0].value, false);
+      equal(groupVisibility[1].value, false);
+
+      // set the first group to false the second group to true
+      groupVisibility = controller.getSlickGridDataset();
+      groupVisibility[0].value = false;
+      groupVisibility[1].value =  true;
+      controller.getView().setVisibility(false, groupVisibility[0].plottables);
+      controller.getView().setVisibility(true, groupVisibility[1].plottables);
+      controller.setSlickGridDataset(groupVisibility);
+
+      controller.toggleVisibility();
+      equal(controller.decompViewDict.scatter.markers[0].visible, true);
+      equal(controller.decompViewDict.scatter.markers[1].visible, false);
+
+      groupVisibility = controller.getSlickGridDataset();
+      equal(groupVisibility[0].value, true);
+      equal(groupVisibility[1].value, false);
+    });
+
     test('Testing setPlottableAttributes helper function', function(assert) {
       // testing with one plottable
       var idx = 0;

--- a/tests/javascript_tests/test_visibility_controller.js
+++ b/tests/javascript_tests/test_visibility_controller.js
@@ -126,7 +126,7 @@ requirejs([
       // set the first group to false the second group to true
       groupVisibility = controller.getSlickGridDataset();
       groupVisibility[0].value = false;
-      groupVisibility[1].value =  true;
+      groupVisibility[1].value = true;
       controller.getView().setVisibility(false, groupVisibility[0].plottables);
       controller.getView().setVisibility(true, groupVisibility[1].plottables);
       controller.setSlickGridDataset(groupVisibility);


### PR DESCRIPTION
Fairly small change that adds a button to toggle visibility. We used to have this in the previous version of Emperor and this was requested during an EMP meeting a couple of months ago by @justinshaffer & @FranckLejzerowicz.

![toggle](https://user-images.githubusercontent.com/375307/128463278-abcb078f-e9af-44f9-9061-682febafacdc.gif)

This should be helpful for dealing with biplot arrows.