### PR TITLE
BUG: Remove rawgit and a bit of jQuery

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,12 +5,15 @@ Emperor ChangeLog
 
 ### Bug Fixes
 
+* Update remote URL to no longer use rawgit.
+  ([#751(https://github.com/biocore/emperor/issues/751)]).
+
 ### New Features
 
 ### Miscellaneous
 
 * Pin Sphinx version to be less than 4.0.
-
+* Jupyter templates no longer require jQuery to add the CSS headers.
 
 # Emperor 1.0.3 (14 Apr 2021)
 -----------------------------

--- a/emperor/core.py
+++ b/emperor/core.py
@@ -24,8 +24,8 @@ from emperor.util import (get_emperor_support_files_dir,
                           validate_and_process_custom_axes, EmperorWarning)
 
 # we are going to use this remote location to load external resources
-REMOTE_URL = ('https://cdn.rawgit.com/biocore/emperor/%s/emperor'
-              '/support_files')
+REMOTE_URL = ('https://cdn.jsdelivr.net/gh/biocore/emperor@%s/emperor/'
+              'support_files')
 LOCAL_URL = "/nbextensions/emperor/support_files"
 
 BASE_DEPENDENCIES_PATH = 'base-dependencies.html'

--- a/emperor/support_files/templates/style-template.html
+++ b/emperor/support_files/templates/style-template.html
@@ -1,8 +1,6 @@
 <script type="text/javascript">
-{% raw %}
-if ($("#emperor-css").length == 0){{
-    $("head").append([
-{% endraw %}
+if (document.querySelector("#emperor-css") === null){
+    document.querySelector("head").insertAdjacentHTML("beforeend",[
         '<link id="emperor-css" rel="stylesheet" type="text/css" href="{{ base_url }}/css/emperor.css">',
         '<link rel="stylesheet" type="text/css" href="{{ base_url }}/vendor/css/jquery-ui.min.css">',
         '<link rel="stylesheet" type="text/css" href="{{ base_url }}/vendor/css/slick.grid.min.css">',
@@ -10,6 +8,6 @@ if ($("#emperor-css").length == 0){{
         '<link rel="stylesheet" type="text/css" href="{{ base_url }}/vendor/css/chosen.min.css">',
         '<link rel="stylesheet" type="text/css" href="{{ base_url }}/vendor/css/jquery.contextMenu.min.css">'
     ]);
-}}
+}
 </script>
 

--- a/emperor/util.py
+++ b/emperor/util.py
@@ -363,16 +363,24 @@ def resolve_stable_url(version, base_url):
     An EmperorWarning is shown when development URLs are used.
     """
     if 'dev' in version:
-        warnings.warn("Plots generated with `remote=True` using a development "
-                      "version of Emperor, may fail to load in the future "
-                      "(only the logo may be displayed instead of the plot). "
-                      "To avoid this, use a release version of Emperor.",
+        warnings.warn("Plots generated with `remote=True` using a development"
+                      " version of Emperor may fail to load (only the logo "
+                      "may be displayed instead of the plot). Using this flag"
+                      " might also load outdated JS or CSS files. If you are "
+                      "doing development, we recommend running nbinstall and "
+                      "sourcing JS and CSS files locally. Otherwise use "
+                      "`remote=True` only with a release version of Emperor.",
                       EmperorWarning)
 
-        # this will need to be fixed when new-api is merged to master
-        return base_url % 'new-api'
-    else:
-        # version names are changed for git tags from betaxx to -beta.xx
-        if 'b' in version:
-            version = version.replace('b', '-beta.')
-        return base_url % version
+        version = version.rstrip('.dev0')
+
+    if 'b' in version:
+        # Version numbers appear in slightly different formats in different
+        # places. Setuptools converts 1.0.0beta19 into 1.0.0b19. This is then
+        # converted to 1.0.0-beta.19 for the git tag.
+        #
+        # The replacement below makes the setuptools version string match what
+        # the git tag will look like.
+        version = version.replace('b', '-beta.')
+
+    return base_url % version

--- a/tests/_test_core_strings.py
+++ b/tests/_test_core_strings.py
@@ -55,10 +55,8 @@ Site constraints	0	0
 
 HTML_STRING = u"""
 <script type="text/javascript">
-
-if ($("#emperor-css").length == 0){{
-    $("head").append([
-
+if (document.querySelector("#emperor-css") === null){
+    document.querySelector("head").insertAdjacentHTML("beforeend",[
         '<link id="emperor-css" rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/css/emperor.css">',
         '<link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/vendor/css/jquery-ui.min.css">',
         '<link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/vendor/css/slick.grid.min.css">',
@@ -66,7 +64,7 @@ if ($("#emperor-css").length == 0){{
         '<link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/vendor/css/chosen.min.css">',
         '<link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/biocore/emperor/new-api/emperor/support_files/vendor/css/jquery.contextMenu.min.css">'
     ]);
-}}
+}
 </script>
 
 <div id='emperor-notebook-0x9cb72f54' style="position: relative; width:100%; height:500px;">
@@ -241,10 +239,8 @@ STANDALONE_HTML_STRING = """<!DOCTYPE html>
     <meta charset="utf-8">
 
     <script type="text/javascript">
-
-if ($("#emperor-css").length == 0){{
-    $("head").append([
-
+if (document.querySelector("#emperor-css") === null){
+    document.querySelector("head").insertAdjacentHTML("beforeend",[
         '<link id="emperor-css" rel="stylesheet" type="text/css" href="./some-local-path//css/emperor.css">',
         '<link rel="stylesheet" type="text/css" href="./some-local-path//vendor/css/jquery-ui.min.css">',
         '<link rel="stylesheet" type="text/css" href="./some-local-path//vendor/css/slick.grid.min.css">',
@@ -252,7 +248,7 @@ if ($("#emperor-css").length == 0){{
         '<link rel="stylesheet" type="text/css" href="./some-local-path//vendor/css/chosen.min.css">',
         '<link rel="stylesheet" type="text/css" href="./some-local-path//vendor/css/jquery.contextMenu.min.css">'
     ]);
-}}
+}
 </script>
 
 
@@ -435,10 +431,8 @@ function($, model, EmperorController) {
 </html>"""
 
 STYLE_STRING = """<script type="text/javascript">
-
-if ($("#emperor-css").length == 0){{
-    $("head").append([
-
+if (document.querySelector("#emperor-css") === null){
+    document.querySelector("head").insertAdjacentHTML("beforeend",[
         '<link id="emperor-css" rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/css/emperor.css">',
         '<link rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/vendor/css/jquery-ui.min.css">',
         '<link rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/vendor/css/slick.grid.min.css">',
@@ -446,7 +440,7 @@ if ($("#emperor-css").length == 0){{
         '<link rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/vendor/css/chosen.min.css">',
         '<link rel="stylesheet" type="text/css" href="/nbextensions/emperor/support_files/vendor/css/jquery.contextMenu.min.css">'
     ]);
-}}
+}
 </script>
 """
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -318,31 +318,31 @@ class TopLevelTests(TestCase):
 
     def test_resolve_stable_url_release(self):
         # we test that no warnings are raised
-        url = 'https://github.com/biocore/emperor/%s/emperor/support_files'
+        url = 'https://github.com/biocore/emperor@%s/emperor/support_files'
         with warnings.catch_warnings(record=True) as w:
             obs = resolve_stable_url('1.0.0b7', url)
             self.assertTrue(len(w) == 0)
             self.assertEqual(obs, url % '1.0.0-beta.7')
 
     def test_resolve_stable_url_release_check_warning(self):
-        url = 'https://github.com/biocore/emperor/%s/emperor/support_files'
+        url = 'https://github.com/biocore/emperor@%s/emperor/support_files'
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            obs = resolve_stable_url('1.0.0b7-dev', url)
+            obs = resolve_stable_url('1.0.0b7.dev', url)
 
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, EmperorWarning))
-            self.assertEqual(obs, url % 'new-api')
+            self.assertEqual(obs, url % '1.0.0-beta.7')
 
     def test_resolve_stable_url_release_number_check_warning(self):
-        url = 'https://github.com/biocore/emperor/%s/emperor/support_files'
+        url = 'https://github.com/biocore/emperor@%s/emperor/support_files'
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            obs = resolve_stable_url('1.0.0b7-dev0', url)
+            obs = resolve_stable_url('1.0.0b7.dev0', url)
 
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, EmperorWarning))
-            self.assertEqual(obs, url % 'new-api')
+            self.assertEqual(obs, url % '1.0.0-beta.7')
 
 
 MAPPING_FILE_DATA = [


### PR DESCRIPTION
- We use jsdelivr instead of rawgit which has better support for
  versioning, etc.

- The style template needed jQuery but some distributions, such as Voilá,
  would not make jQuery available making this template crash.

Fixes #751