### PR TITLE
Fixup: PR 811: install an upper-bounded version of Jinja2 during documentation build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js enviroment
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Build documentation
         shell: bash -l {0}
         run: |
+          pip install 'jinja2<3.1'
           make -C doc html
 
       - name: Run tests and measure coverage

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ Emperor ChangeLog
 ### Bug Fixes
 
 * Update remote URL to no longer use rawgit.
-  ([#751(https://github.com/biocore/emperor/issues/751)]).
+  ([#751](https://github.com/biocore/emperor/issues/751)).
 
 ### New Features
 
@@ -16,6 +16,7 @@ Emperor ChangeLog
 
 * Pin Sphinx version to be less than 4.0.
 * Jupyter templates no longer require jQuery to add the CSS headers.
+* Fix broken test suite with Pandas >=1.5 ([#810](https://github.com/biocore/emperor/issues/810)).
 
 # Emperor 1.0.3 (14 Apr 2021)
 -----------------------------

--- a/emperor/core.py
+++ b/emperor/core.py
@@ -306,9 +306,9 @@ class Emperor(object):
                              'are using metadata and coordinates corresponding'
                              ' to the same dataset.' % kind)
 
+        # sort the elements so we have a deterministic output
+        difference = sorted([str(i) for i in difference])
         if difference and not ignore_missing_samples:
-            # sort the elements so we have a deterministic output
-            difference = sorted([str(i) for i in difference])
 
             # if there's more than 5 missing elements, truncate the list
             if len(difference) > 5:


### PR DESCRIPTION
I'm hopeful that this will resolve the continuous integration failure in #811.

It looks like the [`ImportError: cannot import name 'environmentfilter' from 'jinja2'` error seen in the build logs there](https://github.com/biocore/emperor/actions/runs/3915643613/jobs/6694009088#step:9:24) is a symptom of using some less-recent versions of `sphinx` (as packaged with stable/LTS Ubuntu versions) with quite-recent versions of `Jinja2` -- particularly v3.1.0 of `Jinja2` and beyond.

Until a recent-enough version of `sphinx` is available in the `ubuntu-latest` GitHub runner image, it should be possible to install an upper-bounded version of `Jinja2` as a workaround.

- Ref: https://github.com/sphinx-doc/sphinx/issues/10291

- Ref: https://github.com/pallets/jinja/issues/1630

(please note: this pull request is opened against the master branch instead of the #811 pull request branch so that it is [eligible for continuous integration](https://github.com/biocore/emperor/blob/851154e886efd95ce28f54267f19aecbe2a95188/.github/workflows/main.yml#L7-L8) -- but it's intended to be merged into #811)