### PR TITLE
Update Python unit tests for new version of Pandas and fix CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Run tests and measure coverage
         shell: bash -l {0}
+        env:
+          OPENSSL_CONF: /dev/null
         run: |
           coverage run tests/all_tests.py
           coverage report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     # we can add more versions of node.js in the future
     strategy:
       matrix:
-        python-version: ['3.7', '3.8']
+        python-version: ['3.8']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Emperor
         shell: bash -l {0}
         run: |
-          conda install pip numpy 'scipy>=0.17.0' matplotlib pandas flake8 pep8 jupyter coverage cython scikit-learn requests
+          conda install pip numpy 'scipy>=0.17.0' matplotlib pandas flake8 pep8 jupyter coverage cython scikit-learn requests "notebook<7"
           conda install -c conda-forge phantomjs --yes
           pip install -e ".[all]"
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,11 @@ Emperor ChangeLog
 
 ### Miscellaneous
 
+* Pin `notebook<7` for CI workflow.
+* Update Python unit tests for new Pandas versions.
+* Remove EOL Python version `3.7` from test matrix in CI workflow.
+* Apply a workaround (`OPENSSL_CONF=/dev/null`) for running PhantomJS on `ubuntu-latest` in CI workflow.
+
 
 # Emperor 1.0.4 (10 Jul 2023)
 -----------------------------

--- a/emperor/util.py
+++ b/emperor/util.py
@@ -186,9 +186,9 @@ def preprocess_coords_file(coords_header, coords_data, coords_eigenvals,
 
     # prevent obscure and obfuscated errors
     if is_comparison:
-        assert type(coords_data) == list, ("Cannot process a comparison with "
-                                           "the data from a single "
-                                           "coordinates file")
+        assert isinstance(coords_data, list), \
+            ("Cannot process a comparison with the data from a single "
+             "coordinates file")
 
     mapping_file = [mapping_header] + mapping_data
     coords_file = [coords_header, coords_data]
@@ -196,12 +196,12 @@ def preprocess_coords_file(coords_header, coords_data, coords_eigenvals,
     # number PCoA files; zero for any case except for comparison plots
     clones = 0
 
-    if custom_axes and type(coords_data) == np.ndarray:
+    if custom_axes and isinstance(coords_data, np.ndarray):
         # sequence ported from qiime/scripts/make_3d_plots.py @ 9115351
         get_custom_coords(custom_axes, mapping_file, coords_file)
         remove_nans(coords_file)
         scale_custom_coords(custom_axes, coords_file)
-    elif type(coords_data) == list and not is_comparison:
+    elif isinstance(coords_data, list) and not is_comparison:
         # take the first pcoa file as the master set of coordinates
         master_pcoa = [coords_header[0], coords_data[0],
                        coords_eigenvals[0], coords_pct[0]]
@@ -212,7 +212,7 @@ def preprocess_coords_file(coords_header, coords_data, coords_eigenvals,
                          coords_data, coords_eigenvals, coords_pct)]
 
         # do not apply procrustes, at least not for now
-        coords_data, coords_low, coords_high, eigenvalues_average,\
+        coords_data, coords_low, coords_high, eigenvalues_average, \
             identifiers = summarize_pcoas(master_pcoa, support_pcoas,
                                           method=jackknifing_method,
                                           apply_procrustes=False)
@@ -243,10 +243,10 @@ def preprocess_coords_file(coords_header, coords_data, coords_eigenvals,
             master_pcoa[3] = master_pcoa[3]*100
 
         # return a value containing coords_low and coords_high
-        return identifiers, coords_data, eigenvalues_average, master_pcoa[3],\
+        return identifiers, coords_data, eigenvalues_average, master_pcoa[3], \
             coords_low, coords_high, clones
     # comparison plots are processed almost individually
-    elif type(coords_data) == list and is_comparison:
+    elif isinstance(coords_data, list) and is_comparison:
 
         # indicates the number of files that were totally processed so other
         # functions/APIs are aware of how many times to replicate the metadata
@@ -285,8 +285,8 @@ def preprocess_coords_file(coords_header, coords_data, coords_eigenvals,
 
     # if no coords summary is applied, return None in the corresponding values
     # note that the value of clones will be != 0 for a comparison plot
-    return coords_file[0], coords_file[1], coords_eigenvals, coords_pct, None,\
-        None, clones
+    return coords_file[0], coords_file[1], coords_eigenvals, coords_pct, \
+        None, None, clones
 
 
 def validate_and_process_custom_axes(mf, custom_axes):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -204,7 +204,7 @@ class TopLevelTests(TestCase):
         feature_mf['Second'] = ['No', 'Yes', 'Noes', 'Noooo', 'Yep']
 
         # it is redundant, but the mapping file should remain untouched
-        pd.util.testing.assert_frame_equal(feature_mf, emp.feature_mf,
+        pd.testing.assert_frame_equal(feature_mf, emp.feature_mf,
                                            check_names=False)
 
         self.assertEqual(emp.base_url, 'https://cdn.rawgit.com/biocore/emperor'
@@ -225,7 +225,7 @@ class TopLevelTests(TestCase):
                                        'f.PC.481', 'f.PC.354'])
         empty_mf['all'] = 'All elements'
 
-        pd.util.testing.assert_frame_equal(empty_mf, emp.feature_mf,
+        pd.testing.assert_frame_equal(empty_mf, emp.feature_mf,
                                            check_names=False)
 
         self.assertEqual(emp.base_url, 'https://cdn.rawgit.com/biocore/emperor'
@@ -293,7 +293,7 @@ class TopLevelTests(TestCase):
 
             expected.loc['PC.634'] = ['This element has no metadata'] * 3
 
-            pd.util.testing.assert_frame_equal(expected.sort_index(),
+            pd.testing.assert_frame_equal(expected.sort_index(),
                                                emp.mf.sort_index(),
                                                check_names=False)
 
@@ -315,7 +315,7 @@ class TopLevelTests(TestCase):
 
             expected.loc['f.PC.636'] = ['This element has no metadata'] * 2
 
-            pd.util.testing.assert_frame_equal(expected.sort_index(),
+            pd.testing.assert_frame_equal(expected.sort_index(),
                                                emp.feature_mf.sort_index(),
                                                check_names=False)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -205,7 +205,7 @@ class TopLevelTests(TestCase):
 
         # it is redundant, but the mapping file should remain untouched
         pd.testing.assert_frame_equal(feature_mf, emp.feature_mf,
-                                           check_names=False)
+                                      check_names=False)
 
         self.assertEqual(emp.base_url, 'https://cdn.rawgit.com/biocore/emperor'
                                        '/new-api/emperor/support_files')
@@ -226,7 +226,7 @@ class TopLevelTests(TestCase):
         empty_mf['all'] = 'All elements'
 
         pd.testing.assert_frame_equal(empty_mf, emp.feature_mf,
-                                           check_names=False)
+                                      check_names=False)
 
         self.assertEqual(emp.base_url, 'https://cdn.rawgit.com/biocore/emperor'
                                        '/new-api/emperor/support_files')
@@ -294,8 +294,8 @@ class TopLevelTests(TestCase):
             expected.loc['PC.634'] = ['This element has no metadata'] * 3
 
             pd.testing.assert_frame_equal(expected.sort_index(),
-                                               emp.mf.sort_index(),
-                                               check_names=False)
+                                          emp.mf.sort_index(),
+                                          check_names=False)
 
         expected = self.feature_mf.copy()
 
@@ -316,8 +316,8 @@ class TopLevelTests(TestCase):
             expected.loc['f.PC.636'] = ['This element has no metadata'] * 2
 
             pd.testing.assert_frame_equal(expected.sort_index(),
-                                               emp.feature_mf.sort_index(),
-                                               check_names=False)
+                                          emp.feature_mf.sort_index(),
+                                          check_names=False)
 
     def test_no_overlap(self):
         mf = self.mf.copy()

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -69,7 +69,7 @@ class TopLevelTests(TestCase):
         pd.testing.assert_frame_equal(self.df, emp.mf)
 
         pd.testing.assert_frame_equal(emp.ordination.samples,
-                                           self.samples)
+                                      self.samples)
 
     def test_scatterplot_reordered(self):
         emp = scatterplot(self.df, x='num_3', y='num_2', z='num_1',
@@ -85,7 +85,7 @@ class TopLevelTests(TestCase):
         reordered = self.samples[['num_3', 'num_2', 'num_1', 'num_4']].copy()
 
         pd.testing.assert_frame_equal(emp.ordination.samples,
-                                           reordered)
+                                      reordered)
 
     def test_bad_column_names(self):
         np.testing.assert_raises(ValueError, scatterplot, self.df, x=':L')

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -66,9 +66,9 @@ class TopLevelTests(TestCase):
         self.assertTrue(isinstance(emp, Emperor))
         self.assertEqual(emp.dimensions, 4)
 
-        pd.util.testing.assert_frame_equal(self.df, emp.mf)
+        pd.testing.assert_frame_equal(self.df, emp.mf)
 
-        pd.util.testing.assert_frame_equal(emp.ordination.samples,
+        pd.testing.assert_frame_equal(emp.ordination.samples,
                                            self.samples)
 
     def test_scatterplot_reordered(self):
@@ -80,11 +80,11 @@ class TopLevelTests(TestCase):
         self.assertEqual(emp.base_url, 'https://cdn.rawgit.com/biocore/'
                          'emperor/new-api/emperor/support_files')
 
-        pd.util.testing.assert_frame_equal(self.df, emp.mf)
+        pd.testing.assert_frame_equal(self.df, emp.mf)
 
         reordered = self.samples[['num_3', 'num_2', 'num_1', 'num_4']].copy()
 
-        pd.util.testing.assert_frame_equal(emp.ordination.samples,
+        pd.testing.assert_frame_equal(emp.ordination.samples,
                                            reordered)
 
     def test_bad_column_names(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -282,7 +282,7 @@ class TopLevelTests(TestCase):
         mf = pd.DataFrame(data=MAPPING_FILE_DATA, columns=columns)
         obs = validate_and_process_custom_axes(mf, ['DOB'])
         exp = pd.DataFrame(data=MAPPING_FILE_DATA_CONVERTED, columns=columns)
-        pd.util.testing.assert_frame_equal(obs, exp)
+        pd.testing.assert_frame_equal(obs, exp)
 
     def test_custom_axes_non_existent_names(self):
         columns = ['SampleID', 'BarcodeSequence', 'LinkerPrimerSequence',

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -121,7 +121,7 @@ class TopLevelTests(TestCase):
         """Check correct processing is applied to the coords"""
 
         # case with custom axes
-        out_coords_header, out_coords_data, out_eigenvals, out_pcts,\
+        out_coords_header, out_coords_data, out_eigenvals, out_pcts, \
             out_coords_low, out_coords_high, o_clones = preprocess_coords_file(
                 self.coords_header, self.coords_data, self.coords_eigenvalues,
                 self.coords_pct, self.mapping_file_headers_gradient,
@@ -147,7 +147,7 @@ class TopLevelTests(TestCase):
                 self.assertAlmostEqual(out_el_sub, exp_el_sub)
 
         # case for jackknifing, based on qiime/tests/test_util.summarize_pcoas
-        out_coords_header, out_coords_data, out_eigenvals, out_pcts,\
+        out_coords_header, out_coords_data, out_eigenvals, out_pcts, \
             out_coords_low, out_coords_high, o_clones = preprocess_coords_file(
                 self.jk_coords_header, self.jk_coords_data,
                 self.jk_coords_eigenvalues, self.jk_coords_pcts,
@@ -170,7 +170,7 @@ class TopLevelTests(TestCase):
                                    [0.04787136, 0.025, 0.07071068]]))
 
         # test custom axes and jackknifed plots
-        out_coords_header, out_coords_data, out_eigenvals, out_pcts,\
+        out_coords_header, out_coords_data, out_eigenvals, out_pcts, \
             out_coords_low, out_coords_high, o_clones = preprocess_coords_file(
                 self.jk_coords_header_gradient, self.jk_coords_data_gradient,
                 self.jk_coords_eigenvalues_gradient,
@@ -209,7 +209,7 @@ class TopLevelTests(TestCase):
         self.assertEqual(o_clones, 0)
 
         # test that pct_variation_below_one is working
-        out_coords_header, out_coords_data, out_eigenvals, out_pcts,\
+        out_coords_header, out_coords_data, out_eigenvals, out_pcts, \
             out_coords_low, out_coords_high, o_clones = preprocess_coords_file(
                 self.jk_coords_header_gradient, self.jk_coords_data_gradient,
                 self.jk_coords_eigenvalues_gradient,
@@ -238,7 +238,7 @@ class TopLevelTests(TestCase):
             self.coords_pct, self.mapping_file_headers_gradient,
             self.mapping_file_data_gradient, None, None, True)
 
-        out_coords_header, out_coords_data, out_eigenvals, out_pcts,\
+        out_coords_header, out_coords_data, out_eigenvals, out_pcts, \
             out_coords_low, out_coords_high, o_clones = preprocess_coords_file(
                 self.jk_coords_header, self.jk_coords_data,
                 self.jk_coords_eigenvalues, self.jk_coords_pcts,


### PR DESCRIPTION
These changes should allow the GitHub "Emperor CI" workflow to succeed again. They remove Python 3.7 (now EOL) from the test matrix, apply a workaround to get PhantomJS to work on the newest `ubuntu-latest` runner, and update the Python unit tests to work with new versions of Pandas. They also fix the `notebook` dependency to `<7`, since Jupyter 7 uses an incompatible extension system based on Jupyter Lab's.