### PR TITLE
MAINT: `pkg_resources` deprecation

### DIFF
--- a/emperor/__init__.py
+++ b/emperor/__init__.py
@@ -6,11 +6,7 @@
 # The full license is in the file LICENSE.md, distributed with this software.
 # ----------------------------------------------------------------------------
 
-try:
-    from importlib.metadata import version
-except ImportError:
-    from importlib_metadata import version
-
+from importlib.metadata import version
 __version__ = version('emperor')  # noqa
 
 from emperor.core import Emperor


### PR DESCRIPTION
Replaces call to `pkg_resources` with the relevant `importlib` command.

We recently completed an org-wide sprint in QIIME 2 to remove all deprecated calls to `pkg_resources`. After completing this, I noticed there was still a deprecation warning within our latest QIIME 2 development environments:
```
/Users/elizabethgehret/miniconda3/envs/q2dev-amp/lib/python3.10/site-packages/emperor/__init__.py:9: UserWarning: pkg_resources is deprecated as an API.
See https://setuptools.pypa.io/en/latest/pkg_resources.html.
The pkg_resources package is slated for removal as early as 2025-11-30.
Refrain from using this package or pin to Setuptools<81.
```
Our next release is at the end of this month, so this change ensures continued compatibility post-release after `pkg_resources` is fully removed in November/December of this year.