### PR TITLE
replace deprecated assertRaisesRegexp with assertRaisesRegex

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -237,7 +237,7 @@ class TopLevelTests(TestCase):
             self.ord_res.proportion_explained[:1].copy()
 
         with self.assertRaisesRegex(ValueError, "Ordinations with less than "
-                                     "two dimensions are not supported"):
+                                    "two dimensions are not supported"):
             Emperor(self.ord_res, self.mf, remote=False)
 
     def test_initial_unbalanced_more_than_five(self):
@@ -245,32 +245,32 @@ class TopLevelTests(TestCase):
         mf.drop(['PC.354', 'PC.355', 'PC.356', 'PC.481', 'PC.607', 'PC.636'],
                 inplace=True)
         with self.assertRaisesRegex(KeyError, "There are samples not "
-                                     "included in the sample mapping file. "
-                                     "Override this error by using the "
-                                     "`ignore_missing_samples` argument. "
-                                     "Showing only the first 5 samples out of "
-                                     "6: PC.354, PC.355, PC.356, PC.481, "
-                                     "PC.607 ..."):
+                                    "included in the sample mapping file. "
+                                    "Override this error by using the "
+                                    "`ignore_missing_samples` argument. "
+                                    "Showing only the first 5 samples out of "
+                                    "6: PC.354, PC.355, PC.356, PC.481, "
+                                    "PC.607 ..."):
             Emperor(self.ord_res, mf, remote=self.url)
 
     def test_initial_unbalanced(self):
         mf = self.mf.copy()
         mf.drop(['PC.354'], inplace=True)
         with self.assertRaisesRegex(KeyError, "There are samples not "
-                                     "included in the sample mapping file. "
-                                     "Override this error by using the "
-                                     "`ignore_missing_samples` argument. "
-                                     "Offending samples: PC.354"):
+                                    "included in the sample mapping file. "
+                                    "Override this error by using the "
+                                    "`ignore_missing_samples` argument. "
+                                    "Offending samples: PC.354"):
             Emperor(self.ord_res, mf, remote=self.url)
 
         # test feature metadata
         fmf = self.feature_mf.copy()
         fmf.drop(['f.PC.636'], inplace=True)
         with self.assertRaisesRegex(KeyError, "There are features not "
-                                     "included in the feature mapping file. "
-                                     "Override this error by using the "
-                                     "`ignore_missing_samples` argument. "
-                                     "Offending features: f.PC.636"):
+                                    "included in the feature mapping file. "
+                                    "Override this error by using the "
+                                    "`ignore_missing_samples` argument. "
+                                    "Offending features: f.PC.636"):
             Emperor(self.biplot, self.mf, fmf, remote=self.url)
 
     def test_initial_unbalanced_ignore(self):
@@ -323,20 +323,20 @@ class TopLevelTests(TestCase):
         mf.index = mf.index + '.not'
 
         with self.assertRaisesRegex(ValueError, 'None of the sample '
-                                     'identifiers match between the metadata '
-                                     'and the coordinates. Verify that you are'
-                                     ' using metadata and coordinates '
-                                     'corresponding to the same dataset.'):
+                                    'identifiers match between the metadata '
+                                    'and the coordinates. Verify that you are'
+                                    ' using metadata and coordinates '
+                                    'corresponding to the same dataset.'):
             Emperor(self.ord_res, mf, remote=self.url)
 
         fmf = self.feature_mf.copy()
         fmf.index = fmf.index + '.not'
 
         with self.assertRaisesRegex(ValueError, 'None of the feature '
-                                     'identifiers match between the metadata '
-                                     'and the coordinates. Verify that you are'
-                                     ' using metadata and coordinates '
-                                     'corresponding to the same dataset.'):
+                                    'identifiers match between the metadata '
+                                    'and the coordinates. Verify that you are'
+                                    ' using metadata and coordinates '
+                                    'corresponding to the same dataset.'):
             Emperor(self.biplot, self.mf, fmf, remote=self.url)
 
     def test_get_template(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -236,7 +236,7 @@ class TopLevelTests(TestCase):
         self.ord_res.proportion_explained = \
             self.ord_res.proportion_explained[:1].copy()
 
-        with self.assertRaisesRegexp(ValueError, "Ordinations with less than "
+        with self.assertRaisesRegex(ValueError, "Ordinations with less than "
                                      "two dimensions are not supported"):
             Emperor(self.ord_res, self.mf, remote=False)
 
@@ -244,7 +244,7 @@ class TopLevelTests(TestCase):
         mf = self.mf.copy()
         mf.drop(['PC.354', 'PC.355', 'PC.356', 'PC.481', 'PC.607', 'PC.636'],
                 inplace=True)
-        with self.assertRaisesRegexp(KeyError, "There are samples not "
+        with self.assertRaisesRegex(KeyError, "There are samples not "
                                      "included in the sample mapping file. "
                                      "Override this error by using the "
                                      "`ignore_missing_samples` argument. "
@@ -256,7 +256,7 @@ class TopLevelTests(TestCase):
     def test_initial_unbalanced(self):
         mf = self.mf.copy()
         mf.drop(['PC.354'], inplace=True)
-        with self.assertRaisesRegexp(KeyError, "There are samples not "
+        with self.assertRaisesRegex(KeyError, "There are samples not "
                                      "included in the sample mapping file. "
                                      "Override this error by using the "
                                      "`ignore_missing_samples` argument. "
@@ -266,7 +266,7 @@ class TopLevelTests(TestCase):
         # test feature metadata
         fmf = self.feature_mf.copy()
         fmf.drop(['f.PC.636'], inplace=True)
-        with self.assertRaisesRegexp(KeyError, "There are features not "
+        with self.assertRaisesRegex(KeyError, "There are features not "
                                      "included in the feature mapping file. "
                                      "Override this error by using the "
                                      "`ignore_missing_samples` argument. "
@@ -322,7 +322,7 @@ class TopLevelTests(TestCase):
         mf = self.mf.copy()
         mf.index = mf.index + '.not'
 
-        with self.assertRaisesRegexp(ValueError, 'None of the sample '
+        with self.assertRaisesRegex(ValueError, 'None of the sample '
                                      'identifiers match between the metadata '
                                      'and the coordinates. Verify that you are'
                                      ' using metadata and coordinates '
@@ -332,7 +332,7 @@ class TopLevelTests(TestCase):
         fmf = self.feature_mf.copy()
         fmf.index = fmf.index + '.not'
 
-        with self.assertRaisesRegexp(ValueError, 'None of the feature '
+        with self.assertRaisesRegex(ValueError, 'None of the feature '
                                      'identifiers match between the metadata '
                                      'and the coordinates. Verify that you are'
                                      ' using metadata and coordinates '


### PR DESCRIPTION
Hi,

This was a second patch that has been laying around in the Debian packaging for a long time:

Same reasoning as here: https://github.com/biopython/biopython/issues/2273

